### PR TITLE
fix: clear remaining Codacy strlen finding for PR #247

### DIFF
--- a/src/srclib/bf.c
+++ b/src/srclib/bf.c
@@ -795,12 +795,12 @@ const unsigned char *prbf_str_replace(const unsigned char *orig, const char *rep
         orig += len_front + len_rep; // move to next "end of rep"
     }
 #ifdef __STDC_WANT_SECURE_LIB__
-    strcpy_s(tmp, (strlen(orig) + 1) * sizeof(char), orig);
+    strcpy_s(tmp, result_len - (size_t)(tmp - result), orig);
 #else
     {
-        const size_t rem = strlen(orig);
+        /* Remaining bytes including NUL are known from result_len (avoid strlen). */
+        const size_t rem = result_len - (size_t)(tmp - result);
         memcpy(tmp, orig, rem);
-        tmp[rem] = '\0';
     }
 #endif
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Babysit fix for https://github.com/aegoroff/hc/pull/247 (now merged into `master`).

- Cleared the remaining Codacy Flawfinder `strlen` finding in `prbf_str_replace` by sizing the final remainder copy from known `result_len` (secure and non-secure paths).
- Landed on `develop`; CI went green (Codacy / Linux / Windows); PR #247 subsequently merged.

## Test plan
- [x] Codacy Static Code Analysis: 0 new issues / up to standards
- [x] Linux Build passed
- [x] Windows Build passed
- [x] PR #247 merged to `master`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b7ba5517-a3d8-4705-98c2-1cef548a7388"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7ba5517-a3d8-4705-98c2-1cef548a7388"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

