### PR TITLE
ci: use Windows PowerShell on self-hosted runner (PR 249)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,11 @@ jobs:
     name: Windows Build
     needs: [ prepare ]
     runs-on: [self-hosted, windows, x64]
+    # Self-hosted Windows runner has Windows PowerShell 5.1, not pwsh
+    # (GitHub's Windows default). Force powershell for all run: steps.
+    defaults:
+      run:
+        shell: powershell
 
     steps:
       - uses: actions/checkout@v6
@@ -74,7 +79,6 @@ jobs:
       # .zig-cache round-trip to GitHub Cache (local zig-out/.zig-cache persists).
       - name: Resolve Zig
         id: zig
-        shell: pwsh
         run: |
           $required = "0.16.0"
           $cmd = Get-Command zig -ErrorAction SilentlyContinue
@@ -115,17 +119,16 @@ jobs:
       # APR provisioning and CUDA .cu compilation.
       - uses: step-security/msvc-dev-cmd@v1
       - name: Build (zig)
-        shell: pwsh
         run: ./windows_build.ps1
         env:
           HC_VERSION: ${{ needs.prepare.outputs.version }}
           PROJECT_BASE_PATH: ${{ github.workspace }}
 
       - name: Create artifact directory
-        run: mkdir -p ${{ env.RELEASE_DIR }}
+        run: New-Item -ItemType Directory -Force -Path ${{ env.RELEASE_DIR }} | Out-Null
       - name: Packaging
         if: endsWith(github.ref, 'merge') == false
-        run: cp -v ./bin/*.gz ./${{ env.RELEASE_DIR }}/
+        run: Copy-Item -Path ./bin/*.gz -Destination ./${{ env.RELEASE_DIR }}/ -Verbose
       - uses: actions/upload-artifact@v7
         if: endsWith(github.ref, 'merge') == false
         with:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Fixes Windows Build CI on PR #249: the self-hosted runner has Windows PowerShell 5.1 (`powershell`) but not PowerShell Core (`pwsh`), so `shell: pwsh` failed immediately with `pwsh: command not found`.
- Defaults the Windows job to `powershell` and converts packaging steps to PowerShell cmdlets.

## Context
This is a merge-readiness fix for https://github.com/aegoroff/hc/pull/249 (`zig` → `develop`). The same commit is pushed to `zig` so PR 249 CI re-runs (workflow only triggers on PRs into `develop`/`master`).

## Test plan
- [ ] Windows Build progresses past Resolve Zig / Build steps
- [ ] Linux gnu + musl remain green
- [ ] No unresolved review threads on #249
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e0b19bf5-d44d-4cfd-b129-55b220900a74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0b19bf5-d44d-4cfd-b129-55b220900a74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

