### PR TITLE
feat(l2h): recursive dir walk via where d.recursive == true

### DIFF
--- a/docs/l2h-semantics.md
+++ b/docs/l2h-semantics.md
@@ -34,7 +34,6 @@ Read left to right: open one file, keep it if it's non-empty, then print its MD5
 The following are **not** part of l2h:
 
 - **Method calls** (`x.foo(...)`) — these are parsed, then rejected as a semantic error. Use property access (`x.prop`) instead (§4).
-- **Built-in recursive directory walk** — `from dir` only lists immediate children. Recursion is left for a later version (§3.4).
 - **Bytecode / register VM** — the runtime is a tree-walking interpreter, with no global instruction tape and no instruction-index coupling.
 - **Interpreter performance tuning beyond correctness.**
 
@@ -68,6 +67,16 @@ where f.size > 1000
 select f.sha1;
 ```
 `from dir` binds a directory; the *second* `from` then iterates its immediate regular files. Subdirectories and symlinks are skipped (§3.4).
+
+**Same, but recurse into subdirectories:**
+```text
+from dir d in '/tmp'
+where d.recursive == true
+from file f in d
+where f.size > 1000
+select f.sha1;
+```
+Same idea as `limit`/`offset` on files: set `d.recursive` in a `where` *before* you open the files with `from file f in d` (§4.6).
 
 **Join two sources on equal digests:**
 ```text
@@ -117,7 +126,7 @@ A value is always one of these runtime kinds:
 | `Dir` | A directory identified by path — the source of enumeration, not a row by itself |
 | `Hash` | A restore source: a digest string; the algorithm is chosen via a property or `select` |
 | `Int` | Signed integer (sizes, numeric literals) |
-| `Bool` | A predicate result |
+| `Bool` | Predicate results, plus the literals `true` and `false` |
 | `Record` | An anonymous object / product of `let`, `join`, or `{…}` shaping |
 | `Seq(T)` | A lazy sequence of values or environments |
 
@@ -155,13 +164,13 @@ Any additional `from` in the body works as a **SelectMany**: for each outer row,
 
 ### 3.4 Directory enumeration
 
-When `from file f in <Dir>` iterates a directory:
+When `from file f in <Dir>` walks a directory:
 
-- **Flat only** — immediate children, nothing deeper.
-- **Regular files only** — **skip all symlinks** (whether they point at a file or a directory) and skip subdirectories.
-- **No recursive walk** — a future version may expose recursion via filters and synthetic properties, but not through a built-in recursive `from dir`.
+- **Flat by default** — only the files sitting directly in that folder. Want the whole tree? Set `recursive` on the dir first (§4.6).
+- **Regular files only** — symlinks are always skipped (whether they point at a file or a directory). Flat mode also skips subdirectories; recursive mode descends into real directories but still ignores symlink entries (no follow).
+- **No magic recursive `from dir`** — recursion is just a flag on the `Dir` value, not a separate source form.
 
-Child order is implementation-defined but **deterministic** for a given filesystem snapshot (the chosen order is documented in tests, e.g. lexicographic by name).
+Order is implementation-defined, but for a given snapshot of the filesystem it's stable: lexicographic by full path (see the tests).
 
 ---
 
@@ -210,6 +219,7 @@ Which properties are allowed depends on the **runtime kind** of the receiver. As
 | `String` | `<hash>` | `String` | Hex digest of string bytes |
 | `Hash` | `<hash>` | `String` | **Restore** path: treats the bound digest as the input digest for algorithm `<hash>` (same meaning as legacy `from hash … select x.md5`) — this is *not* "hash the digest characters as a string" |
 | `Dir` | `path` | `String` | Path identifying the directory (no I/O; projects the bound path). Use `from file f in d` to reach the files inside |
+| `Dir` | `recursive` | `Bool` | `false` = this folder only (default); `true` = whole tree. Set it in `where` — see §4.6 |
 | `Record` | field name | field value | Fields introduced by `{…}`, `let`, or join shaping |
 | `Int` / `Bool` / `Seq` | — | — | No properties in v1.0 |
 
@@ -250,6 +260,25 @@ select f.md5;
 
 Reading `f.limit` / `f.offset` outside a bind (e.g. in `select`) yields the currently bound integers (defaults if never bound). That is allowed but rarely useful — the intended use is binding inside `where`.
 
+### 4.6 Directory recursion (`recursive`)
+
+`recursive` is a **`Dir`-only** flag. Left alone, `from file f in d` sees only files in that folder. Flip it on, and the same `from` walks the whole tree — same trick as binding `limit`/`offset` on a file:
+
+```text
+from dir d in '/tmp'
+where d.recursive == true
+from file f in d
+select f.path;
+```
+
+Write `d.recursive == true` (or `== false`) in a `where`. That doesn't filter rows; it stamps the flag onto `d` and the comparison itself is always true. Operand order doesn't matter (`true == d.recursive` is fine). Put this `where` **before** the `from file f in d` that should recurse — a bind that shows up afterward won't rewind and re-scan.
+
+Under `&&` / `||`, the same scoping rules as §4.5 apply: conjuncts bind first; each side of an `||` gets its own binds, and a failed left side restores the previous `Dir`/`File` params before trying the right.
+
+Defaults and edges: unbound means `false` (flat). `recursive` on a `File`, `String`, etc. is just an invalid property. Symlinks stay skipped even when recursing — same as flat listing and like `hc -r`.
+
+You *can* read `d.recursive` in a `select`, but there's rarely a reason to; the useful place is that early `where`.
+
 ---
 
 ## 5. Queries & expressions
@@ -275,8 +304,7 @@ Multiple queries can appear in one translation unit, separated by semicolons; co
 
 Inside clauses you write expressions. The supported forms are:
 
-- String and integer literals
-- Range identifier
+- String, integer, and boolean literals — including bare `true` / `false` in `where` and `select`- Range identifier
 - Property access `id.prop`
 - Relational operators: `==`, `!=`, `>`, `>=`, `<`, `<=`, `~`, `!~`
 - Boolean operators: `&&`, `||`, `!`, and parentheses
@@ -446,7 +474,7 @@ There's no global `sources` tape and no instruction-index coupling.
 | Diagnostics | `fehler` via `diag.zig` (parse + compile-time/runtime spans from AST/`Expr`) |
 | Tests | `frontend_test.zig`, `compile_test.zig`, `interpret.zig`; `zig build test-l2h` |
 | Methods | **Out of scope** for v1.0 — parse only; compile-time check → `UnsupportedMethodCall` |
-| Recursive dir walk | **Out of scope** for v1.0 — flat listing only (§3.4) |
+| Recursive dir walk | Yes — `where d.recursive == true`, then `from file f in d` (§3.4 / §4.6) |
 
 **Known limitations**: some mixed/`unknown` sequence shapes and I/O failures are detected only at runtime.
 
@@ -466,5 +494,7 @@ This section explains why the behavior is what it is — it's reference material
 | Hex digests | **Print lowercase**; compare case-insensitive |
 | `group proj by key` element | Record `{ key, items }` where `items` is the sequence of grouped elements |
 | File `limit` / `offset` | Bound via `==` in `where` only meaningfully; apply to subsequent file hashes like `hc` (§4.5) |
+| Dir `recursive` | Set with `== true`/`false` in `where`; later `from file … in d` respects it (§4.6); never follows symlinks |
+| Boolean literals | `true` / `false` work as values and as bare predicates (§5.2) |
 
 No remaining open questions.

--- a/src/l2h/compile.zig
+++ b/src/l2h/compile.zig
@@ -244,6 +244,10 @@ pub fn compileExpr(allocator: std.mem.Allocator, node: *const c.fend_node_t, dep
             .span = sp,
             .kind = .{ .int_lit = node.value.number },
         },
+        c.node_type_boolean_literal => out.* = .{
+            .span = sp,
+            .kind = .{ .bool_lit = node.value.number != 0 },
+        },
         c.node_type_relation => out.* = .{
             .span = sp,
             .kind = .{
@@ -570,6 +574,7 @@ fn inferExprType(
         },
         .string_lit => .string,
         .int_lit => .int,
+        .bool_lit => .bool,
         .name => |name| scope.get(name) orelse fail(e.span, error.UndefinedName),
         .unary => |u| switch (u.op) {
             .not_ => blk: {
@@ -637,6 +642,7 @@ fn inferExprType(
             break :blk switch (props.resultKind(access orelse return fail(e.span, error.InvalidProperty))) {
                 .string => .string,
                 .int => .int,
+                .bool => .bool,
             };
         },
     };

--- a/src/l2h/compile_test.zig
+++ b/src/l2h/compile_test.zig
@@ -704,6 +704,130 @@ test "compile+run dir.path projects bound path" {
     try std.testing.expectEqualStrings("", got.err);
 }
 
+test "compile+run dir recursive bind walks nested files" {
+    // Arrange — top-level + one nested file; flat must miss nested
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.writeFile(state.io, .{ .sub_path = "top.txt", .data = "t" });
+    try tmp.dir.createDir(state.io, "sub", std.Io.Dir.Permissions.default_dir);
+    try tmp.dir.writeFile(state.io, .{ .sub_path = "sub/nested.txt", .data = "nn" });
+
+    const dir_path = try tmpQueryPath(std.testing.allocator, tmp);
+    defer std.testing.allocator.free(dir_path);
+
+    const flat_q = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "from dir d in '{s}' from file f in d orderby f.size select f.size;",
+        .{dir_path},
+    );
+    defer std.testing.allocator.free(flat_q);
+
+    const deep_q = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "from dir d in '{s}' where d.recursive == true from file f in d orderby f.size select f.size;",
+        .{dir_path},
+    );
+    defer std.testing.allocator.free(deep_q);
+
+    // Act
+    const flat = try runQuery(flat_q);
+    const deep = try runQuery(deep_q);
+
+    // Assert
+    try std.testing.expectEqualStrings("1\n", flat.out);
+    try std.testing.expectEqualStrings("", flat.err);
+    try std.testing.expectEqualStrings("1\n2\n", deep.out);
+    try std.testing.expectEqualStrings("", deep.err);
+}
+
+test "compile+run dir recursive bind after from file stays flat" {
+    // Arrange — bind too late must not retroactively expand enumeration
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.writeFile(state.io, .{ .sub_path = "top.txt", .data = "t" });
+    try tmp.dir.createDir(state.io, "sub", std.Io.Dir.Permissions.default_dir);
+    try tmp.dir.writeFile(state.io, .{ .sub_path = "sub/nested.txt", .data = "nn" });
+
+    const dir_path = try tmpQueryPath(std.testing.allocator, tmp);
+    defer std.testing.allocator.free(dir_path);
+
+    const query = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "from dir d in '{s}' from file f in d where d.recursive == true select f.size;",
+        .{dir_path},
+    );
+    defer std.testing.allocator.free(query);
+
+    // Act
+    const got = try runQuery(query);
+
+    // Assert
+    try std.testing.expectEqualStrings("1\n", got.out);
+    try std.testing.expectEqualStrings("", got.err);
+}
+
+test "compile+run dir.recursive == int is type mismatch" {
+    // Arrange
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const dir_path = try tmpQueryPath(std.testing.allocator, tmp);
+    defer std.testing.allocator.free(dir_path);
+
+    const query = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "from dir d in '{s}' where d.recursive == 1 select d.path;",
+        .{dir_path},
+    );
+    defer std.testing.allocator.free(query);
+
+    // Act
+    const got = try runQuery(query);
+
+    // Assert
+    try std.testing.expectEqualStrings("type mismatch in expression or clause", got.err);
+}
+
+test "compile+run boolean literals as values and predicates" {
+    // Arrange / Act — dupe outs: runQuery reuses a shared buffer
+    const select_true = try runQuery("from string s in 'a' select true;");
+    const true_out = try std.testing.allocator.dupe(u8, select_true.out);
+    defer std.testing.allocator.free(true_out);
+    try std.testing.expectEqualStrings("", select_true.err);
+
+    const select_false = try runQuery("from string s in 'a' select false;");
+    const false_out = try std.testing.allocator.dupe(u8, select_false.out);
+    defer std.testing.allocator.free(false_out);
+    try std.testing.expectEqualStrings("", select_false.err);
+
+    const where_true = try runQuery("from string s in 'a' where true select s.size;");
+    const where_true_out = try std.testing.allocator.dupe(u8, where_true.out);
+    defer std.testing.allocator.free(where_true_out);
+    try std.testing.expectEqualStrings("", where_true.err);
+
+    const where_false = try runQuery("from string s in 'a' where false select s.size;");
+    try std.testing.expectEqualStrings("", where_false.err);
+    try std.testing.expectEqualStrings("", where_false.out);
+
+    // Assert
+    try std.testing.expectEqualStrings("true\n", true_out);
+    try std.testing.expectEqualStrings("false\n", false_out);
+    try std.testing.expectEqualStrings("1\n", where_true_out);
+}
+
+test "compile+run file.recursive is invalid property" {
+    // Arrange
+    const query = "from file f in 'x' where f.recursive == 1 select f.md5;";
+
+    // Act
+    const got = try runQuery(query);
+
+    // Assert
+    try std.testing.expectEqualStrings("invalid property for this value type", got.err);
+}
+
 test "compile+run dir.size is invalid property" {
     // Arrange
     var tmp = std.testing.tmpDir(.{});

--- a/src/l2h/expr.zig
+++ b/src/l2h/expr.zig
@@ -43,6 +43,7 @@ pub const Span = struct {
 pub const Kind = union(enum) {
     string_lit: []const u8,
     int_lit: i64,
+    bool_lit: bool,
     /// Nested query compiled to a plan during typecheck.
     nested_query: *plan.QueryPlan,
     /// Fresh from `compileExpr`; replaced by `nested_query` in `inferExprType`.

--- a/src/l2h/frontend.zig
+++ b/src/l2h/frontend.zig
@@ -82,6 +82,13 @@ fn createNumberNode(left: ?*c.fend_node_t, right: ?*c.fend_node_t, t: c_int, val
     return node;
 }
 
+/// Boolean literal as a unary-wrapped `node_type_boolean_literal` (value 0/1).
+/// Separate from `fend_on_unary_expression` so `false` is not passed as a null void*.
+pub export fn fend_on_boolean_literal(value: c_int) ?*c.fend_node_t {
+    const lit = createNumberNode(null, null, c.node_type_boolean_literal, value) orelse return null;
+    return createNode(lit, null, c.node_type_unary_expression);
+}
+
 fn signalOom() void {
     // The C build aborts on allocation failure; here we surface a parser error
     // and let yyparse unwind rather than crash the process.

--- a/src/l2h/grammar/frontend.h
+++ b/src/l2h/grammar/frontend.h
@@ -59,6 +59,7 @@ typedef enum unary_exp_type_t {
     unary_exp_type_property_call,
     unary_exp_type_identifier,
     unary_exp_type_mehtod_call,
+    unary_exp_type_boolean,
 } unary_exp_type_t;
 
 typedef struct unary_expr_descriptor_t {
@@ -85,6 +86,7 @@ typedef enum node_type_t {
     node_type_internal_type,
     node_type_string_literal,
     node_type_numeric_literal,
+    node_type_boolean_literal,
     node_type_identifier,
     node_type_property,
     node_type_unary_expression,
@@ -132,6 +134,7 @@ type_info_t* fend_on_complex_type_def(type_def_t type, char* info);
 type_info_t* fend_on_simple_type_def(type_def_t type);
 fend_node_t* fend_on_identifier_declaration(type_info_t* type, fend_node_t* identifier);
 fend_node_t* fend_on_unary_expression(unary_exp_type_t type, void* leftValue, void* rightValue);
+fend_node_t* fend_on_boolean_literal(int value);
 fend_node_t* fend_on_from(fend_node_t* type, fend_node_t* datasource);
 fend_node_t* fend_on_where(fend_node_t* expr);
 fend_node_t* fend_on_releational_expr(fend_node_t* left, fend_node_t* right, cond_op_t relation);

--- a/src/l2h/grammar/l2h.lex
+++ b/src/l2h/grammar/l2h.lex
@@ -55,6 +55,8 @@ CLOSE_BRACE "}"
 OR "||"
 AND "&&"
 NOT "!"
+BOOL_TRUE "true"
+BOOL_FALSE "false"
 UPPER_LETTER [A-Z]
 LOWER_LETTER [a-z]
 DIGIT [0-9]
@@ -88,6 +90,8 @@ ENDL [\r\n]
 {OR} { return OR; }
 {AND} { return AND; }
 {NOT} { return NOT; }
+{BOOL_TRUE} { return BOOL_TRUE; }
+{BOOL_FALSE} { return BOOL_FALSE; }
 {ORDERBY} { return ORDERBY; }
 {ASCENDING} { yylval.ordering = ordering_asc; return ASCENDING; }
 {DESCENDING} { yylval.ordering = ordering_desc; return DESCENDING; }

--- a/src/l2h/grammar/l2h.y
+++ b/src/l2h/grammar/l2h.y
@@ -62,6 +62,8 @@
 
 %token <number> INTEGER
 %token <string> STRING
+%token BOOL_TRUE
+%token BOOL_FALSE
 %token DOT
 %token <string> INVALID_STRING
 
@@ -255,6 +257,8 @@ exclusive_or_expression
 	: OPEN_PAREN boolean_expression CLOSE_PAREN { $$ = $2; }
 	| query_expression_nested { $$ = $1; }
 	| relational_expr { $$ = $1; }
+	| BOOL_TRUE { $$ = fend_on_boolean_literal(1); FLOC($$, @$); }
+	| BOOL_FALSE { $$ = fend_on_boolean_literal(0); FLOC($$, @$); }
 	;
 
 expression
@@ -273,6 +277,8 @@ unary_expression
 	| identifier DOT invocation_expression { if (!fend_is_identifier_defined($1)) lyyerror(@1,"identifier %s undefined", $1->value.string); $$ = fend_on_unary_expression(unary_exp_type_mehtod_call, $1, $3); FLOC($$, @$); }
 	| STRING { $$ = fend_on_unary_expression(unary_exp_type_string, $1, NULL); FLOC($$, @$); }
 	| INTEGER { $$ = fend_on_unary_expression(unary_exp_type_number, (void*)$1, NULL); FLOC($$, @$); }
+	| BOOL_TRUE { $$ = fend_on_boolean_literal(1); FLOC($$, @$); }
+	| BOOL_FALSE { $$ = fend_on_boolean_literal(0); FLOC($$, @$); }
 	;
 	
 anonymous_object

--- a/src/l2h/interpret.zig
+++ b/src/l2h/interpret.zig
@@ -116,7 +116,7 @@ pub fn evalProp(ctx: Ctx, recv: Value, prop: []const u8, sp: expr.Span) Error!Va
     return switch (access) {
         .path => switch (recv) {
             .file => |f| Value.plainStr(f.path),
-            .dir => |path| Value.plainStr(path),
+            .dir => |d| Value.plainStr(d.path),
             else => unreachable,
         },
         .size => switch (recv) {
@@ -130,6 +130,10 @@ pub fn evalProp(ctx: Ctx, recv: Value, prop: []const u8, sp: expr.Span) Error!Va
         },
         .limit => switch (recv) {
             .file => |f| .{ .int = f.limit },
+            else => unreachable,
+        },
+        .recursive => switch (recv) {
+            .dir => |d| .{ .bool = d.recursive },
             else => unreachable,
         },
         .hash_algo => switch (recv) {
@@ -220,25 +224,27 @@ fn asBool(e: *const Expr, v: Value) Error!bool {
     };
 }
 
-// --- file hash window binds (§4.5) ------------------------------------------
+// --- file/dir parameter binds (§4.5 / §4.6) ---------------------------------
 
-const WindowField = enum { limit, offset };
+const ParamField = enum { limit, offset, recursive };
 
-/// `range.limit` / `range.offset` where `range` is a bare name.
-fn windowPropTarget(e: *const Expr) ?struct { name: []const u8, field: WindowField } {
+/// `range.limit` / `range.offset` / `range.recursive` where `range` is a bare name.
+fn paramPropTarget(e: *const Expr) ?struct { name: []const u8, field: ParamField } {
     if (e.kind != .prop) return null;
     const p = e.kind.prop;
     if (p.recv.kind != .name) return null;
-    const field: WindowField = if (std.mem.eql(u8, p.prop, "limit"))
+    const field: ParamField = if (std.mem.eql(u8, p.prop, "limit"))
         .limit
     else if (std.mem.eql(u8, p.prop, "offset"))
         .offset
+    else if (std.mem.eql(u8, p.prop, "recursive"))
+        .recursive
     else
         return null;
     return .{ .name = p.recv.kind.name, .field = field };
 }
 
-fn setFileWindow(allocator: std.mem.Allocator, env: *Env, name: []const u8, field: WindowField, n: i64, sp: expr.Span) Error!void {
+fn setFileWindow(allocator: std.mem.Allocator, env: *Env, name: []const u8, field: ParamField, n: i64, sp: expr.Span) Error!void {
     if (n < 0) return failSpan(sp, error.InvalidWindow);
     const cur = env.get(name) orelse return failSpan(sp, error.UndefinedName);
     if (cur != .file) return failSpan(sp, error.InvalidProperty);
@@ -246,43 +252,68 @@ fn setFileWindow(allocator: std.mem.Allocator, env: *Env, name: []const u8, fiel
     switch (field) {
         .limit => f.limit = n,
         .offset => f.offset = n,
+        .recursive => return failSpan(sp, error.InvalidProperty),
     }
     // put into the shared map (Env may be a shallow copy of the row).
     try env.put(allocator, name, .{ .file = f });
 }
 
-/// Bind `prop_side == int_side` when prop_side is file limit/offset. Returns true if bound.
-fn tryBindWindow(ctx: Ctx, prop_side: *const Expr, int_side: *const Expr, env: *Env, depth: u32) Error!bool {
-    const target = windowPropTarget(prop_side) orelse return false;
-    const v = try unwrapForCompare(int_side, try evalExpr(ctx, int_side, env, depth));
-    if (v != .int) return failExpr(prop_side, error.TypeMismatch);
-    // Use prop span for diagnostics on negative / bad receiver.
-    try setFileWindow(ctx.allocator, env, target.name, target.field, v.int, prop_side.span);
+fn setDirRecursive(allocator: std.mem.Allocator, env: *Env, name: []const u8, flag: bool, sp: expr.Span) Error!void {
+    const cur = env.get(name) orelse return failSpan(sp, error.UndefinedName);
+    if (cur != .dir) return failSpan(sp, error.InvalidProperty);
+    var d = cur.dir;
+    d.recursive = flag;
+    try env.put(allocator, name, .{ .dir = d });
+}
+
+/// Bind `prop_side == value_side` for file window / dir recursive. Returns true if bound.
+fn tryBindParam(ctx: Ctx, prop_side: *const Expr, value_side: *const Expr, env: *Env, depth: u32) Error!bool {
+    const target = paramPropTarget(prop_side) orelse return false;
+    const v = try unwrapForCompare(value_side, try evalExpr(ctx, value_side, env, depth));
+    switch (target.field) {
+        .limit, .offset => {
+            if (v != .int) return failExpr(prop_side, error.TypeMismatch);
+            try setFileWindow(ctx.allocator, env, target.name, target.field, v.int, prop_side.span);
+        },
+        .recursive => {
+            if (v != .bool) return failExpr(prop_side, error.TypeMismatch);
+            try setDirRecursive(ctx.allocator, env, target.name, v.bool, prop_side.span);
+        },
+    }
     return true;
 }
 
-/// Apply limit/offset equality binds reachable through `&&` only (§4.5).
-fn applyWindowBinds(ctx: Ctx, e: *const Expr, env: *Env, depth: u32) Error!void {
+/// Apply limit/offset/recursive equality binds reachable through `&&` only (§4.5 / §4.6).
+fn applyParamBinds(ctx: Ctx, e: *const Expr, env: *Env, depth: u32) Error!void {
     switch (e.kind) {
         .binary => |b| {
             if (b.op == .and_) {
-                try applyWindowBinds(ctx, b.left, env, depth);
-                try applyWindowBinds(ctx, b.right, env, depth);
+                try applyParamBinds(ctx, b.left, env, depth);
+                try applyParamBinds(ctx, b.right, env, depth);
             } else if (b.op == .eq) {
-                if (try tryBindWindow(ctx, b.left, b.right, env, depth)) return;
-                _ = try tryBindWindow(ctx, b.right, b.left, env, depth);
+                if (try tryBindParam(ctx, b.left, b.right, env, depth)) return;
+                _ = try tryBindParam(ctx, b.right, b.left, env, depth);
             }
         },
         else => {},
     }
 }
 
-fn restoreFileWindows(env: *Env, saved: *const Env) void {
+fn restoreParamBinds(env: *Env, saved: *const Env) void {
     var it = env.map.iterator();
     while (it.next()) |e| {
-        if (e.value_ptr.* != .file) continue;
-        if (saved.get(e.key_ptr.*)) |v| {
-            if (v == .file) e.value_ptr.* = v;
+        switch (e.value_ptr.*) {
+            .file => {
+                if (saved.get(e.key_ptr.*)) |v| {
+                    if (v == .file) e.value_ptr.* = v;
+                }
+            },
+            .dir => {
+                if (saved.get(e.key_ptr.*)) |v| {
+                    if (v == .dir) e.value_ptr.* = v;
+                }
+            },
+            else => {},
         }
     }
 }
@@ -291,6 +322,7 @@ pub fn evalExpr(ctx: Ctx, e: *const Expr, env: *Env, depth: u32) Error!Value {
     return switch (e.kind) {
         .string_lit => |s| Value.plainStr(s),
         .int_lit => |n| .{ .int = n },
+        .bool_lit => |b| .{ .bool = b },
         .nested_query => |q| {
             // Nested plan was compiled during typecheck; bound the runtime stack
             // in step with the analysis-time limit.
@@ -315,7 +347,7 @@ pub fn evalExpr(ctx: Ctx, e: *const Expr, env: *Env, depth: u32) Error!Value {
         .binary => |b| {
             switch (b.op) {
                 .and_ => {
-                    try applyWindowBinds(ctx, e, env, depth);
+                    try applyParamBinds(ctx, e, env, depth);
                     const l = try evalExpr(ctx, b.left, env, depth);
                     if (!(try asBool(b.left, l))) return .{ .bool = false };
                     const r = try evalExpr(ctx, b.right, env, depth);
@@ -324,11 +356,11 @@ pub fn evalExpr(ctx: Ctx, e: *const Expr, env: *Env, depth: u32) Error!Value {
                 .or_ => {
                     var saved = try env.clone(ctx.allocator);
                     defer saved.deinit(ctx.allocator);
-                    try applyWindowBinds(ctx, b.left, env, depth);
+                    try applyParamBinds(ctx, b.left, env, depth);
                     const l = try evalExpr(ctx, b.left, env, depth);
                     if (try asBool(b.left, l)) return .{ .bool = true };
-                    restoreFileWindows(env, &saved);
-                    try applyWindowBinds(ctx, b.right, env, depth);
+                    restoreParamBinds(env, &saved);
+                    try applyParamBinds(ctx, b.right, env, depth);
                     const r = try evalExpr(ctx, b.right, env, depth);
                     return .{ .bool = try asBool(b.right, r) };
                 },
@@ -341,8 +373,8 @@ pub fn evalExpr(ctx: Ctx, e: *const Expr, env: *Env, depth: u32) Error!Value {
                 },
                 .eq, .neq => {
                     if (b.op == .eq) {
-                        if (try tryBindWindow(ctx, b.left, b.right, env, depth)) return .{ .bool = true };
-                        if (try tryBindWindow(ctx, b.right, b.left, env, depth)) return .{ .bool = true };
+                        if (try tryBindParam(ctx, b.left, b.right, env, depth)) return .{ .bool = true };
+                        if (try tryBindParam(ctx, b.right, b.left, env, depth)) return .{ .bool = true };
                     }
                     const l = try unwrapForCompare(b.left, try evalExpr(ctx, b.left, env, depth));
                     const r = try unwrapForCompare(b.right, try evalExpr(ctx, b.right, env, depth));
@@ -394,7 +426,11 @@ pub fn sinkPrint(ctx: Ctx, v: Value) Error!void {
             try ctx.out.writeAll(f.path);
             try ctx.out.writeAll("\n");
         },
-        .dir, .hash => |path| {
+        .dir => |d| {
+            try ctx.out.writeAll(d.path);
+            try ctx.out.writeAll("\n");
+        },
+        .hash => |path| {
             try ctx.out.writeAll(path);
             try ctx.out.writeAll("\n");
         },
@@ -418,13 +454,13 @@ fn openAs(ctx: Ctx, kind: plan.SourceKind, path_or_payload: []const u8) Error!Va
         .dir => {
             var d = std.Io.Dir.cwd().openDir(ctx.io, path_or_payload, .{}) catch return error.IoFailure;
             d.close(ctx.io);
-            return .{ .dir = path_or_payload };
+            return .{ .dir = .{ .path = path_or_payload } };
         },
     }
 }
 
-fn listFilesInDir(ctx: Ctx, dir_path: []const u8) Error![]Value {
-    var root = std.Io.Dir.cwd().openDir(ctx.io, dir_path, .{ .iterate = true }) catch return error.IoFailure;
+fn listFilesInDir(ctx: Ctx, dir: value.DirVal) Error![]Value {
+    var root = std.Io.Dir.cwd().openDir(ctx.io, dir.path, .{ .iterate = true }) catch return error.IoFailure;
     defer root.close(ctx.io);
 
     var list: std.ArrayListUnmanaged(Value) = .empty;
@@ -433,14 +469,32 @@ fn listFilesInDir(ctx: Ctx, dir_path: []const u8) Error![]Value {
     var names: std.ArrayListUnmanaged([]const u8) = .empty;
     defer names.deinit(ctx.allocator);
 
-    var it = root.iterate();
-    while (true) {
-        const maybe = it.next(ctx.io) catch return error.IoFailure;
-        const entry = maybe orelse break;
-        // Skip symlinks and non-files (directories, etc.).
-        if (entry.kind != .file) continue;
-        const name = try ctx.allocator.dupe(u8, entry.name);
-        try names.append(ctx.allocator, name);
+    if (dir.recursive) {
+        // Selective walker: enter() failures skip that subtree; siblings stay reachable.
+        var walker = root.walkSelectively(ctx.allocator) catch return error.OutOfMemory;
+        defer walker.deinit();
+        while (true) {
+            const maybe = walker.next(ctx.io) catch return error.IoFailure;
+            const entry = maybe orelse break;
+            if (entry.kind == .directory) {
+                walker.enter(ctx.io, entry) catch continue;
+                continue;
+            }
+            // Skip symlinks and non-files (same policy as flat listing).
+            if (entry.kind != .file) continue;
+            const full = try std.fs.path.join(ctx.allocator, &.{ dir.path, entry.path });
+            try names.append(ctx.allocator, full);
+        }
+    } else {
+        var it = root.iterate();
+        while (true) {
+            const maybe = it.next(ctx.io) catch return error.IoFailure;
+            const entry = maybe orelse break;
+            // Skip symlinks and non-files (directories, etc.).
+            if (entry.kind != .file) continue;
+            const full = try std.fs.path.join(ctx.allocator, &.{ dir.path, entry.name });
+            try names.append(ctx.allocator, full);
+        }
     }
 
     std.mem.sort([]const u8, names.items, {}, struct {
@@ -449,8 +503,7 @@ fn listFilesInDir(ctx: Ctx, dir_path: []const u8) Error![]Value {
         }
     }.less);
 
-    for (names.items) |name| {
-        const full = try std.fs.path.join(ctx.allocator, &.{ dir_path, name });
+    for (names.items) |full| {
         try list.append(ctx.allocator, .{ .file = .{ .path = full } });
     }
     return try list.toOwnedSlice(ctx.allocator);
@@ -781,7 +834,8 @@ fn expandSourceValues(
             const payload = switch (src_val) {
                 .string => |s| s.bytes,
                 .file => |f| f.path,
-                .dir, .hash => |p| p,
+                .dir => |d| d.path,
+                .hash => |p| p,
                 else => return failExpr(e, error.TypeMismatch),
             };
             const bound = openAs(ctx, kind, payload) catch |err| return failExpr(e, err);

--- a/src/l2h/props.zig
+++ b/src/l2h/props.zig
@@ -12,16 +12,19 @@ pub const Access = enum {
     offset,
     /// File hash window length (semantics §4.5).
     limit,
+    /// Dir recursive enumeration flag (semantics §4.6).
+    recursive,
     /// `prop` is a known hash algorithm name.
     hash_algo,
 };
 
-pub const ResultKind = enum { string, int };
+pub const ResultKind = enum { string, int, bool };
 
 pub fn resultKind(access: Access) ResultKind {
     return switch (access) {
         .path, .hash_algo => .string,
         .size, .offset, .limit => .int,
+        .recursive => .bool,
     };
 }
 
@@ -58,6 +61,7 @@ pub fn lookup(recv: plan.SourceKind, prop: []const u8) ?Access {
         },
         .dir => {
             if (std.mem.eql(u8, prop, "path")) return .path;
+            if (std.mem.eql(u8, prop, "recursive")) return .recursive;
             return null;
         },
     };
@@ -82,19 +86,22 @@ test "lookup matches semantics catalog for range kinds" {
     try std.testing.expect(lookup(.hash, "size") == null);
 
     try std.testing.expectEqual(@as(?Access, .path), lookup(.dir, "path"));
+    try std.testing.expectEqual(@as(?Access, .recursive), lookup(.dir, "recursive"));
     try std.testing.expect(lookup(.dir, "size") == null);
+    try std.testing.expect(lookup(.file, "recursive") == null);
 
     try std.testing.expectEqual(ResultKind.string, resultKind(.path));
     try std.testing.expectEqual(ResultKind.int, resultKind(.size));
     try std.testing.expectEqual(ResultKind.int, resultKind(.offset));
     try std.testing.expectEqual(ResultKind.int, resultKind(.limit));
+    try std.testing.expectEqual(ResultKind.bool, resultKind(.recursive));
     try std.testing.expectEqual(ResultKind.string, resultKind(.hash_algo));
 }
 
 test "ofValue maps range-kind values only" {
     try std.testing.expectEqual(@as(?plan.SourceKind, .string), ofValue(value.Value.plainStr("x")));
     try std.testing.expectEqual(@as(?plan.SourceKind, .file), ofValue(value.Value.filePath("a")));
-    try std.testing.expectEqual(@as(?plan.SourceKind, .dir), ofValue(.{ .dir = "d" }));
+    try std.testing.expectEqual(@as(?plan.SourceKind, .dir), ofValue(.{ .dir = .{ .path = "d" } }));
     try std.testing.expectEqual(@as(?plan.SourceKind, .hash), ofValue(.{ .hash = "00" }));
     try std.testing.expect(ofValue(.{ .int = 1 }) == null);
     try std.testing.expect(ofValue(.{ .bool = true }) == null);

--- a/src/l2h/value.zig
+++ b/src/l2h/value.zig
@@ -17,10 +17,17 @@ pub const FileVal = struct {
     offset: i64 = 0,
 };
 
+/// Directory binding with optional recursive enumeration (§3.4 / §4.6).
+pub const DirVal = struct {
+    path: []const u8,
+    /// When true, `from file f in d` walks the whole tree (regular files only).
+    recursive: bool = false,
+};
+
 pub const Value = union(enum) {
     string: Str,
     file: FileVal,
-    dir: []const u8,
+    dir: DirVal,
     hash: []const u8,
     int: i64,
     bool: bool,


### PR DESCRIPTION
Add boolean literals and a Dir recursive bind so from file can walk trees like hc -r, without changing the flat default.