### PR TITLE
feat(windows): ship portable core2 archive with soft CRC32C

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,7 @@ jobs:
       - name: Packaging
         if: endsWith(github.ref, 'merge') == false
         run: |
+          # haswell TGZ + core2 portable TGZ (no installer for core2)
           Copy-Item -Path ./bin/*.gz -Destination ./${{ env.RELEASE_DIR }}/ -Verbose
           # NSIS setup (src/Install/Release), also mirrored under bin/ by windows_build.ps1
           Copy-Item -Path ./src/Install/Release/*.exe -Destination ./${{ env.RELEASE_DIR }}/ -Verbose

--- a/build.zig
+++ b/build.zig
@@ -512,15 +512,31 @@ fn addCryptoLib(
         }
     } else if (is_x86_64 and is_windows) {
         // MSVC/COFF target: the unix .S kernels don't assemble, so compile the
-        // intrinsic C kernels (same SIMD degree as the asm path) instead. AVX512
-        // stays off via BLAKE3_NO_AVX512 (matches the unix build's active paths).
-        // Each file needs its own -m flag so the compiler only emits that ISA.
-        const simd = [_]struct { file: []const u8, flags: []const []const u8 }{
-            .{ .file = "blake3_avx2.c", .flags = &.{ "-O3", "-fno-sanitize=undefined", "-mavx2" } },
-            .{ .file = "blake3_sse41.c", .flags = &.{ "-O3", "-fno-sanitize=undefined", "-msse4.1" } },
-            .{ .file = "blake3_sse2.c", .flags = &.{ "-O3", "-fno-sanitize=undefined", "-msse2" } },
+        // intrinsic C kernels instead. AVX512 stays off via BLAKE3_NO_AVX512.
+        //
+        // Only emit kernels whose ISA is in the *module* CPU features: under
+        // `-Dcpu=core2`, per-file `-mavx2`/`-msse4.1` do not override `-mcpu
+        // core2` on windows-msvc (always_inline / builtin target-feature
+        // errors). Haswell keeps avx2+sse41+sse2; core2 keeps sse2 only.
+        const feats = target.result.cpu.features;
+        const has_avx2 = std.Target.x86.featureSetHas(feats, .avx2);
+        const has_sse41 = std.Target.x86.featureSetHas(feats, .sse4_1);
+        const has_sse2 = std.Target.x86.featureSetHas(feats, .sse2);
+        if (!has_avx2) mod.addCMacro("BLAKE3_NO_AVX2", "1");
+        if (!has_sse41) mod.addCMacro("BLAKE3_NO_SSE41", "1");
+        if (!has_sse2) mod.addCMacro("BLAKE3_NO_SSE2", "1");
+
+        const simd = [_]struct {
+            file: []const u8,
+            flags: []const []const u8,
+            enabled: bool,
+        }{
+            .{ .file = "blake3_avx2.c", .flags = &.{ "-O3", "-fno-sanitize=undefined", "-mavx2" }, .enabled = has_avx2 },
+            .{ .file = "blake3_sse41.c", .flags = &.{ "-O3", "-fno-sanitize=undefined", "-msse4.1" }, .enabled = has_sse41 },
+            .{ .file = "blake3_sse2.c", .flags = &.{ "-O3", "-fno-sanitize=undefined", "-msse2" }, .enabled = has_sse2 },
         };
         for (simd) |e| {
+            if (!e.enabled) continue;
             mod.addCSourceFile(.{
                 .file = b.path(b.fmt("{s}/{s}", .{ srclib, e.file })),
                 .flags = e.flags,

--- a/build.zig
+++ b/build.zig
@@ -369,7 +369,8 @@ fn resolveTarget(b: *std.Build) std.Build.ResolvedTarget {
     }
 
     // Match CMake `-march=haswell` for x86_64: enables SSE4.2/crc32 used by
-    // crc32.c. Only replace the portable baseline default — honor `-Dcpu=…`.
+    // crc32.c's HW CRC32C path. Only replace the portable baseline default —
+    // honor `-Dcpu=…` (e.g. Windows core2 portable builds).
     // aarch64-macos defaults to apple_m1 (Apple Silicon baseline for M1+).
     const arch = query.cpu_arch orelse builtin.cpu.arch;
     const os = query.os_tag orelse builtin.target.os.tag;

--- a/src/hc/hashes.zig
+++ b/src/hc/hashes.zig
@@ -5,7 +5,8 @@ const c = @import("c");
 // libtomcrypt hashes (ripemd256/320) share the hash_state union.
 const ltc = @import("ltc");
 
-/// CRC32C needs Intel SSE4.2 (`_mm_crc32_*`); not offered on aarch64/etc.
+/// CRC32C is offered on x86/x86_64 (SSE4.2 HW, or software on older CPUs
+/// such as core2). Not offered on aarch64/etc.
 pub const have_crc32c = switch (builtin.cpu.arch) {
     .x86_64, .x86 => true,
     else => false,
@@ -619,7 +620,7 @@ pub const hashes = [_]HashDefinition{
         .digest = zigHashDigest(Blake2s256),
     },
 
-    // ---- CRC32 / CRC32C (srclib; CRC32C needs SSE4.2 / haswell target) ----
+    // ---- CRC32 / CRC32C (srclib; CRC32C is HW on SSE4.2, soft on core2) ----
     .{
         .name = "crc32",
         .hash_length = c.CRC32_HASH_SIZE,

--- a/src/srclib/crc32.c
+++ b/src/srclib/crc32.c
@@ -11,17 +11,18 @@
 
 #include "crc32.h"
 
-#if HC_HAVE_CRC32C
-#if defined(_MSC_VER)
-#include <intrin.h>
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
 #include <xmmintrin.h>
-#else  // !defined(_MSC_VER)
-#include <nmmintrin.h>
-#include <xmmintrin.h>
-#endif  // defined(_MSC_VER)
 #define PREFETCH(location) _mm_prefetch(location, _MM_HINT_T0)
+#if HC_CRC32C_HW
+#if defined(_MSC_VER) && !defined(__clang__)
+#include <intrin.h>
 #else
-// Software CRC32 (lookup tables) on non-x86; no SSE prefetch / CRC32C HW.
+#include <nmmintrin.h>
+#endif
+#endif
+#else
+// Non-x86: no SSE prefetch / CRC32C.
 #define PREFETCH(location) ((void)0)
 #endif
 
@@ -593,6 +594,9 @@ static const uint32_t crc32_lookup[16][256] =
 #define FINALIZATION_VALUE INITIALIZATION_VALUE
 
 #if HC_HAVE_CRC32C
+static uint32_t prcrc32c_calculate(uint32_t crc, const char* buf, size_t len);
+
+#if HC_CRC32C_HW
 // Performs H/W CRC operations
 #define CALC_CRC(op, crc, type, buf, len)                                      \
   do {                                                                         \
@@ -601,10 +605,43 @@ static const uint32_t crc32_lookup[16][256] =
       (crc) = op((crc), *(type *)(buf));                                       \
     }                                                                          \
   } while (0)
+#else
+// Reflect Castagnoli poly 0x1EDC6F41 — same digest as `_mm_crc32_*`.
+static const uint32_t crc32c_table[256] = {
+    0x00000000, 0xF26B8303, 0xE13B70F7, 0x1350F3F4, 0xC79A971F, 0x35F1141C, 0x26A1E7E8, 0xD4CA64EB,
+    0x8AD958CF, 0x78B2DBCC, 0x6BE22838, 0x9989AB3B, 0x4D43CFD0, 0xBF284CD3, 0xAC78BF27, 0x5E133C24,
+    0x105EC76F, 0xE235446C, 0xF165B798, 0x030E349B, 0xD7C45070, 0x25AFD373, 0x36FF2087, 0xC494A384,
+    0x9A879FA0, 0x68EC1CA3, 0x7BBCEF57, 0x89D76C54, 0x5D1D08BF, 0xAF768BBC, 0xBC267848, 0x4E4DFB4B,
+    0x20BD8EDE, 0xD2D60DDD, 0xC186FE29, 0x33ED7D2A, 0xE72719C1, 0x154C9AC2, 0x061C6936, 0xF477EA35,
+    0xAA64D611, 0x580F5512, 0x4B5FA6E6, 0xB93425E5, 0x6DFE410E, 0x9F95C20D, 0x8CC531F9, 0x7EAEB2FA,
+    0x30E349B1, 0xC288CAB2, 0xD1D83946, 0x23B3BA45, 0xF779DEAE, 0x05125DAD, 0x1642AE59, 0xE4292D5A,
+    0xBA3A117E, 0x4851927D, 0x5B016189, 0xA96AE28A, 0x7DA08661, 0x8FCB0562, 0x9C9BF696, 0x6EF07595,
+    0x417B1DBC, 0xB3109EBF, 0xA0406D4B, 0x522BEE48, 0x86E18AA3, 0x748A09A0, 0x67DAFA54, 0x95B17957,
+    0xCBA24573, 0x39C9C670, 0x2A993584, 0xD8F2B687, 0x0C38D26C, 0xFE53516F, 0xED03A29B, 0x1F682198,
+    0x5125DAD3, 0xA34E59D0, 0xB01EAA24, 0x42752927, 0x96BF4DCC, 0x64D4CECF, 0x77843D3B, 0x85EFBE38,
+    0xDBFC821C, 0x2997011F, 0x3AC7F2EB, 0xC8AC71E8, 0x1C661503, 0xEE0D9600, 0xFD5D65F4, 0x0F36E6F7,
+    0x61C69362, 0x93AD1061, 0x80FDE395, 0x72966096, 0xA65C047D, 0x5437877E, 0x4767748A, 0xB50CF789,
+    0xEB1FCBAD, 0x197448AE, 0x0A24BB5A, 0xF84F3859, 0x2C855CB2, 0xDEEEDFB1, 0xCDBE2C45, 0x3FD5AF46,
+    0x7198540D, 0x83F3D70E, 0x90A324FA, 0x62C8A7F9, 0xB602C312, 0x44694011, 0x5739B3E5, 0xA55230E6,
+    0xFB410CC2, 0x092A8FC1, 0x1A7A7C35, 0xE811FF36, 0x3CDB9BDD, 0xCEB018DE, 0xDDE0EB2A, 0x2F8B6829,
+    0x82F63B78, 0x709DB87B, 0x63CD4B8F, 0x91A6C88C, 0x456CAC67, 0xB7072F64, 0xA457DC90, 0x563C5F93,
+    0x082F63B7, 0xFA44E0B4, 0xE9141340, 0x1B7F9043, 0xCFB5F4A8, 0x3DDE77AB, 0x2E8E845F, 0xDCE5075C,
+    0x92A8FC17, 0x60C37F14, 0x73938CE0, 0x81F80FE3, 0x55326B08, 0xA759E80B, 0xB4091BFF, 0x466298FC,
+    0x1871A4D8, 0xEA1A27DB, 0xF94AD42F, 0x0B21572C, 0xDFEB33C7, 0x2D80B0C4, 0x3ED04330, 0xCCBBC033,
+    0xA24BB5A6, 0x502036A5, 0x4370C551, 0xB11B4652, 0x65D122B9, 0x97BAA1BA, 0x84EA524E, 0x7681D14D,
+    0x2892ED69, 0xDAF96E6A, 0xC9A99D9E, 0x3BC21E9D, 0xEF087A76, 0x1D63F975, 0x0E330A81, 0xFC588982,
+    0xB21572C9, 0x407EF1CA, 0x532E023E, 0xA145813D, 0x758FE5D6, 0x87E466D5, 0x94B49521, 0x66DF1622,
+    0x38CC2A06, 0xCAA7A905, 0xD9F75AF1, 0x2B9CD9F2, 0xFF56BD19, 0x0D3D3E1A, 0x1E6DCDEE, 0xEC064EED,
+    0xC38D26C4, 0x31E6A5C7, 0x22B65633, 0xD0DDD530, 0x0417B1DB, 0xF67C32D8, 0xE52CC12C, 0x1747422F,
+    0x49547E0B, 0xBB3FFD08, 0xA86F0EFC, 0x5A048DFF, 0x8ECEE914, 0x7CA56A17, 0x6FF599E3, 0x9D9E1AE0,
+    0xD3D3E1AB, 0x21B862A8, 0x32E8915C, 0xC083125F, 0x144976B4, 0xE622F5B7, 0xF5720643, 0x07198540,
+    0x590AB964, 0xAB613A67, 0xB831C993, 0x4A5A4A90, 0x9E902E7B, 0x6CFBAD78, 0x7FAB5E8C, 0x8DC0DD8F,
+    0xE330A81A, 0x115B2B19, 0x020BD8ED, 0xF0605BEE, 0x24AA3F05, 0xD6C1BC06, 0xC5914FF2, 0x37FACCF1,
+    0x69E9F0D5, 0x9B8273D6, 0x88D28022, 0x7AB90321, 0xAE7367CA, 0x5C18E4C9, 0x4F48173D, 0xBD23943E,
+    0xF36E6F75, 0x0105EC76, 0x12551F82, 0xE03E9C81, 0x34F4F86A, 0xC69F7B69, 0xD5CF889D, 0x27A40B9E,
+    0x79B737BA, 0x8BDCB4B9, 0x988C474D, 0x6AE7C44E, 0xBE2DA0A5, 0x4C4623A6, 0x5F16D052, 0xAD7D5351,
+};
 #endif
-
-#if HC_HAVE_CRC32C
-uint32_t prcrc32_sse42_calculate(uint32_t crc, const char* buf, size_t len);
 #endif
 
 void crc32_init(crc32_context_t* ctx) {
@@ -613,7 +650,7 @@ void crc32_init(crc32_context_t* ctx) {
 
 #if HC_HAVE_CRC32C
 void crc32c_init(crc32_context_t* ctx) {
-    // Must be 0: prcrc32_sse42_calculate XORs INITIALIZATION_VALUE itself.
+    // Must be 0: prcrc32c_calculate XORs INITIALIZATION_VALUE itself.
     // DIGEST_BODY used to zero the stack ctx; Zig digest uses `undefined` + init.
     ctx->crc = 0;
 }
@@ -677,7 +714,7 @@ void crc32_final(crc32_context_t* ctx, uint8_t* hash) {
 
 #if HC_HAVE_CRC32C
 void crc32c_update(crc32_context_t* ctx, const void* data, size_t len) {
-    ctx->crc = prcrc32_sse42_calculate(ctx->crc, data, len);
+    ctx->crc = prcrc32c_calculate(ctx->crc, data, len);
 }
 
 void crc32c_final(crc32_context_t* ctx, uint8_t* hash) {
@@ -688,35 +725,35 @@ void crc32c_final(crc32_context_t* ctx, uint8_t* hash) {
 }
 
 /**
- * Calculates CRC-32C using Intel's SSE 4.2 instruction set
- *
- * @param crc The initial CRC to use for the operation
- * @param buf The buffer storing the data whose CRC is to be calculated
- * @param len The size of the buffer
- * @return The CRC-32C of the data in the buffer
+ * Calculates CRC-32C (Castagnoli). Uses SSE 4.2 `_mm_crc32_*` when the
+ * compile target has that ISA; otherwise a software lookup table (core2).
  */
-uint32_t prcrc32_sse42_calculate(uint32_t crc, const char* buf, size_t len) {
-    // If the string is empty, return the initial crc
+static uint32_t prcrc32c_calculate(uint32_t crc, const char* buf, size_t len) {
     if (len == 0)
         return crc;
 
-    // XOR the initial CRC with INT_MAX
     crc ^= INITIALIZATION_VALUE;
 
-    // Align the input to the word boundary
+#if HC_CRC32C_HW
     for (; (len > 0) && ((size_t)buf & ALIGN_MASK); len--, buf++) {
         crc = _mm_crc32_u8(crc, *buf);
     }
 
-    // Blast off the CRC32 calculation on hardware
 #if defined(__x86_64__) || defined(_M_X64)
     CALC_CRC(_mm_crc32_u64, crc, uint64_t, buf, len);
 #endif
     CALC_CRC(_mm_crc32_u32, crc, uint32_t, buf, len);
     CALC_CRC(_mm_crc32_u16, crc, uint16_t, buf, len);
     CALC_CRC(_mm_crc32_u8, crc, uint8_t, buf, len);
+#else
+    {
+        const uint8_t* p = (const uint8_t*)buf;
+        while (len-- != 0) {
+            crc = crc32c_table[(crc ^ *p++) & 0xFF] ^ (crc >> 8);
+        }
+    }
+#endif
 
-    // XOR again with INT_MAX
     return (crc ^= FINALIZATION_VALUE);
 }
 #endif // HC_HAVE_CRC32C

--- a/src/srclib/crc32.h
+++ b/src/srclib/crc32.h
@@ -28,14 +28,21 @@ void crc32_init(crc32_context_t* ctx);
 void crc32_update(crc32_context_t* ctx, const void* data, size_t len);
 void crc32_final(crc32_context_t* ctx, uint8_t* hash);
 
-// CRC32C uses Intel SSE4.2 `_mm_crc32_*` — available only on x86/x86_64.
+// CRC32C (Castagnoli) is offered on x86/x86_64. With SSE4.2 / CRC32 ISA it uses
+// `_mm_crc32_*`; otherwise a software table path (needed for -mcpu=core2).
 #if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
 #define HC_HAVE_CRC32C 1
+#if defined(__SSE4_2__) || defined(__CRC32__)
+#define HC_CRC32C_HW 1
+#else
+#define HC_CRC32C_HW 0
+#endif
 void crc32c_init(crc32_context_t* ctx);
 void crc32c_update(crc32_context_t* ctx, const void* data, size_t len);
 void crc32c_final(crc32_context_t* ctx, uint8_t* hash);
 #else
 #define HC_HAVE_CRC32C 0
+#define HC_CRC32C_HW 0
 #endif
 
 #ifdef __cplusplus

--- a/windows_build.ps1
+++ b/windows_build.ps1
@@ -3,7 +3,8 @@
   Hybrid build under `zig build` for Windows: builds hc/l2h for the
   x86_64-windows-msvc target, runs unit tests + the C# black-box regression,
   produces a TGZ artefact (hc + l2h + LICENSE) and the NSIS installer
-  (hc.setup.*.exe; hc only).
+  (hc.setup.*.exe; hc only). Also builds a portable core2 TGZ (no installer)
+  for older CPUs without SSE4.2 / SHA-NI.
 
 .DESCRIPTION
   Provisioning: scripts/build_external_libs.ps1 downloads/builds OpenSSL
@@ -15,6 +16,10 @@
   parity with the Linux gnu build: build.zig auto-detects nvcc (CUDA_PATH /
   CUDA_PATH_V* / stock Program Files install). Missing toolkit is a hard fail
   (pass -Dcuda=false only for intentional CPU-only tooling builds).
+
+  Default CPU is haswell (SSE4.2 CRC32C HW + OpenSSL SHA-NI at runtime). A
+  second `-Dcpu=core2` build ships as an archive only: soft CRC32C and OpenSSL
+  software digests for older Intel CPUs; no NSIS installer.
 
   NSIS builds src/Install mainHLINQ.nsi after staging hc.exe to
   src/Binplace-x64/Release — same layout as the former msbuild Setup target.
@@ -328,4 +333,38 @@ if ($Arch -eq "x86_64") {
     Write-Output "Installer: $($SetupExe.FullName)"
 } else {
     Write-Output "==> NSIS installer skipped (arch=$Arch; only x86_64)"
+}
+
+# 9. Portable core2 build (x86_64 only): soft CRC32C + OpenSSL software digests
+#    for CPUs without SSE4.2 / SHA-NI. Archive only — no tests re-run, no NSIS.
+if ($Arch -eq "x86_64") {
+    Write-Output "==> zig build -Dtarget=$Triple -Dcpu=core2 -Doptimize=$ZigOptimize -Dversion=$Version"
+    $Core2Args = @("build", "-Dtarget=$Triple", "-Dcpu=core2", "-Doptimize=$ZigOptimize", "-Dversion=$Version")
+    & zig @Core2Args
+    if ($LASTEXITCODE -ne 0) { throw "zig build (core2) failed" }
+
+    $PkgNameCore2 = "hc-$Version-$Arch-pc-windows-msvc-core2"
+    $StageCore2 = Join-Path $env:TEMP "hc-pkg-core2-$(Get-Random)"
+    New-Item -ItemType Directory -Force -Path $StageCore2 | Out-Null
+    try {
+        Copy-Item "$OutDir\bin\hc.exe" (Join-Path $StageCore2 "hc.exe") -Force
+        $MembersCore2 = @("hc.exe")
+        $L2hExeCore2 = "$OutDir\bin\l2h.exe"
+        if (Test-Path -LiteralPath $L2hExeCore2) {
+            Copy-Item $L2hExeCore2 (Join-Path $StageCore2 "l2h.exe") -Force
+            $MembersCore2 += "l2h.exe"
+        }
+        if (Test-Path -LiteralPath "LICENSE.txt") {
+            Copy-Item "LICENSE.txt" (Join-Path $StageCore2 "LICENSE.txt") -Force
+            $MembersCore2 += "LICENSE.txt"
+        }
+        $TarballCore2 = Join-Path $BinDir "$PkgNameCore2.tar.gz"
+        & tar -C $StageCore2 -czvf $TarballCore2 @MembersCore2
+        if ($LASTEXITCODE -ne 0) { throw "core2 packaging failed" }
+        Write-Output "Package (core2): $TarballCore2"
+    } finally {
+        Remove-Item -Recurse -Force $StageCore2 -ErrorAction SilentlyContinue
+    }
+} else {
+    Write-Output "==> core2 portable build skipped (arch=$Arch; only x86_64)"
 }


### PR DESCRIPTION
Allow -Dcpu=core2 builds by falling back to table CRC32C when SSE4.2 is absent, and package a Windows-only core2 tarball (no NSIS) for older CPUs.