### PR TITLE
fix(test): make dir pytest order-independent for musl.

### DIFF
--- a/linux_build.sh
+++ b/linux_build.sh
@@ -25,9 +25,10 @@ OUT_DIR="zig-out"
 BIN_DIR="bin"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "${SCRIPT_DIR}"
-# pytest runner resolves hc via PROJECT_BASE_PATH/build-x86_64-linux-gnu-Release/hc
+# pytest runner resolves hc via PROJECT_BASE_PATH/build-x86_64-linux-${ABI}-Release/hc
 # when set; default to the repo root so local runs match CI.
 export PROJECT_BASE_PATH="${PROJECT_BASE_PATH:-${SCRIPT_DIR}}"
+export HC_TEST_ABI="${HC_TEST_ABI:-${ABI}}"
 
 mkdir -p "${BIN_DIR}"
 TEST_RESULTS_DIR="${SCRIPT_DIR}/test-results"
@@ -109,11 +110,11 @@ if [[ "${ARCH}" = "x86_64" ]] && [[ "${OS}" = "linux" ]]; then
 fi
 
 # 5. pytest black-box regression. runner.py looks for
-#    ${PROJECT_BASE_PATH}/build-x86_64-linux-gnu-Release/hc — point that at the
-#    zig-built binary. Only gnu/x86_64/linux: musl is an artefact, not the test host.
+#    ${PROJECT_BASE_PATH}/build-x86_64-linux-${ABI}-Release/hc — point that at the
+#    zig-built binary. x86_64/linux only (musl artefact is runnable on the gnu host).
 #    JUnit XML lands in test-results/ for dorny/test-reporter in CI.
-if [[ "${ARCH}" = "x86_64" ]] && [[ "${OS}" = "linux" ]] && [[ "${ABI}" = "gnu" ]]; then
-  COMPAT_DIR="build-x86_64-linux-gnu-${BUILD_CONF}"
+if [[ "${ARCH}" = "x86_64" ]] && [[ "${OS}" = "linux" ]]; then
+  COMPAT_DIR="build-x86_64-linux-${ABI}-${BUILD_CONF}"
   mkdir -p "${COMPAT_DIR}"
   ln -sfn "${SCRIPT_DIR}/${OUT_DIR}/bin/hc" "${COMPAT_DIR}/hc"
   ln -sfn "${SCRIPT_DIR}/${OUT_DIR}/bin/l2h" "${COMPAT_DIR}/l2h"
@@ -134,11 +135,12 @@ if [[ "${ARCH}" = "x86_64" ]] && [[ "${OS}" = "linux" ]] && [[ "${ABI}" = "gnu" 
   source "${SCRIPT_DIR}/.venv-tst/bin/activate"
   python -m pip install -q -r src/_tst.py/requirements.txt
   export HC_TEST_DIR="${TEST_RESULTS_DIR}/_tst.py-workdir"
+  export HC_TEST_ABI="${ABI}"
   # Parallel via xdist; file → group "file", crack → group "crack" (GPU VRAM),
   # each group serial on one worker (--dist loadgroup).
   python -m pytest src/_tst.py \
     -n auto --dist loadgroup \
-    --junitxml="${TEST_RESULTS_DIR}/pytest-linux-gnu.xml"
+    --junitxml="${TEST_RESULTS_DIR}/pytest-linux-${ABI}.xml"
 fi
 
 # 6. TGZ packaging: one archive with hc + l2h + LICENSE.

--- a/src/_tst.py/runner.py
+++ b/src/_tst.py/runner.py
@@ -29,11 +29,12 @@ def resolve_hc_path() -> Path:
     configuration = "Debug" if os.environ.get("HC_TEST_DEBUG") else "Release"
     if os.name == "nt":
         candidate = base / "x64" / configuration / "hc.exe"
+    elif os.environ.get("PROJECT_BASE_PATH"):
+        # linux_build.sh links zig-out into build-x86_64-linux-${ABI}-Release/hc
+        abi = os.environ.get("HC_TEST_ABI", "gnu")
+        candidate = base / f"build-x86_64-linux-{abi}-{configuration}" / "hc"
     else:
-        if os.environ.get("PROJECT_BASE_PATH"):
-            candidate = base / f"build-x86_64-linux-gnu-{configuration}" / "hc"
-        else:
-            candidate = base / "build" / "hc"
+        candidate = base / "build" / "hc"
     if candidate.is_file():
         return candidate.resolve()
     # Fallback: zig-out after a local `zig build`

--- a/src/_tst.py/test_file.py
+++ b/src/_tst.py/test_file.py
@@ -136,10 +136,11 @@ def test_calc_dir_checksumfile(runner: ProcessRunner, files, h: Hash) -> None:
         h.algorithm, DIR_CMD, SOURCE_OPT, str(files.base_test_dir), "--checksumfile"
     )
 
-    # Assert
-    assert len(results) == 2
-    assert results[0] == FILE_RESULT_SFV_TPL.format(h.empty_string_hash, files.empty_file)
-    assert results[1] == FILE_RESULT_SFV_TPL.format(h.hash_string, files.not_empty_file)
+    # Assert — set: dir walk order is libc/FS-dependent (gnu vs musl).
+    assert set(results) == {
+        FILE_RESULT_SFV_TPL.format(h.empty_string_hash, files.empty_file),
+        FILE_RESULT_SFV_TPL.format(h.hash_string, files.not_empty_file),
+    }
 
 
 @pytest.mark.file
@@ -152,14 +153,11 @@ def test_calc_dir_sfv_crc32(runner: ProcessRunner, files) -> None:
         h.algorithm, DIR_CMD, SOURCE_OPT, str(files.base_test_dir), "--sfv"
     )
 
-    # Assert
-    assert len(results) == 2
-    assert results[0] == FILE_RESULT_SFV_TPL.format(
-        files.empty_file.name, h.empty_string_hash
-    )
-    assert results[1] == FILE_RESULT_SFV_TPL.format(
-        files.not_empty_file.name, h.hash_string
-    )
+    # Assert — set: dir walk order is libc/FS-dependent (gnu vs musl).
+    assert set(results) == {
+        FILE_RESULT_SFV_TPL.format(files.empty_file.name, h.empty_string_hash),
+        FILE_RESULT_SFV_TPL.format(files.not_empty_file.name, h.hash_string),
+    }
 
 
 @pytest.mark.file
@@ -477,12 +475,13 @@ def test_calc_dir_single(runner: ProcessRunner, files, h: Hash) -> None:
     # Act
     results = runner.run(h.algorithm, DIR_CMD, SOURCE_OPT, str(files.base_test_dir))
 
-    # Assert
-    assert len(results) == 2
-    assert results[0] == FILE_RESULT_TPL.format(files.empty_file, h.empty_string_hash, 0)
-    assert results[1] == FILE_RESULT_TPL.format(
-        files.not_empty_file, h.hash_string, len(h.initial_string)
-    )
+    # Assert — set: dir walk order is libc/FS-dependent (gnu vs musl).
+    assert set(results) == {
+        FILE_RESULT_TPL.format(files.empty_file, h.empty_string_hash, 0),
+        FILE_RESULT_TPL.format(
+            files.not_empty_file, h.hash_string, len(h.initial_string)
+        ),
+    }
 
 
 @pytest.mark.file
@@ -499,14 +498,13 @@ def test_calc_dir_base64(runner: ProcessRunner, files, h: Hash) -> None:
         h.algorithm, DIR_CMD, SOURCE_OPT, str(files.base_test_dir), BASE64_OPT
     )
 
-    # Assert
-    assert len(results) == 2
-    assert results[0] == FILE_RESULT_TPL.format(
-        files.empty_file, empty_string_results[0], 0
-    )
-    assert results[1] == FILE_RESULT_TPL.format(
-        files.not_empty_file, string_results[0], len(h.initial_string)
-    )
+    # Assert — set: dir walk order is libc/FS-dependent (gnu vs musl).
+    assert set(results) == {
+        FILE_RESULT_TPL.format(files.empty_file, empty_string_results[0], 0),
+        FILE_RESULT_TPL.format(
+            files.not_empty_file, string_results[0], len(h.initial_string)
+        ),
+    }
 
 
 @pytest.mark.file
@@ -521,14 +519,13 @@ def test_calc_dir_output_to_file(runner: ProcessRunner, files, h: Hash) -> None:
             h.algorithm, DIR_CMD, SOURCE_OPT, str(files.base_test_dir), "-o", save
         )
 
-        # Assert
-        assert results[0] == FILE_RESULT_TPL.format(
-            files.empty_file, h.empty_string_hash, 0
-        )
-        assert results[1] == FILE_RESULT_TPL.format(
-            files.not_empty_file, h.hash_string, len(h.initial_string)
-        )
-        assert len(results) == 2
+        # Assert — set: dir walk order is libc/FS-dependent (gnu vs musl).
+        assert set(results) == {
+            FILE_RESULT_TPL.format(files.empty_file, h.empty_string_hash, 0),
+            FILE_RESULT_TPL.format(
+                files.not_empty_file, h.hash_string, len(h.initial_string)
+            ),
+        }
         assert result_path.is_file()
         # Binary decode preserves Windows CRLF from save.zig (legacy CRT text mode).
         # Path.read_text() would normalize \r\n → \n and break the os.linesep match


### PR DESCRIPTION
Dir walk order differs between gnu and musl libc; assert sets instead of positions, and resolve hc via HC_TEST_ABI.