### PR TITLE
chore: drop bf digestToHexUpper in favor of fmt {X}

### DIFF
--- a/src/hc/bf.zig
+++ b/src/hc/bf.zig
@@ -81,14 +81,6 @@ fn formatCommifyF(buf: []u8, value: f64) []const u8 {
     return formatCommify(buf, @intFromFloat(@round(@min(value, CLAMP))));
 }
 
-fn digestToHexUpper(digest: []const u8, out: []u8) []const u8 {
-    for (digest, 0..) |b, i| {
-        _ = std.fmt.bufPrint(out[i * 2 ..][0..2], "{X:0>2}", .{b}) catch unreachable;
-    }
-    return out[0 .. digest.len * 2];
-}
-
-/// Parse hex into `out` (same truncation as old `lib_hex_str_2_byte_array`).
 fn parseHashHex(hash_hex: []const u8, out: []u8) void {
     @memset(out, 0);
     const n = @min(out.len, hash_hex.len / 2);
@@ -166,7 +158,7 @@ pub fn crackHash(
             hash_def.digest(digest.ptr, probe.ptr, probe.len);
         }
         var hexbuf: [128]u8 = undefined;
-        const hex = digestToHexUpper(digest, &hexbuf);
+        const hex = std.fmt.bufPrint(&hexbuf, "{X}", .{digest}) catch unreachable;
 
         lib.startTimer(io);
         _ = try runBruteForce(

--- a/src/hc/cli.zig
+++ b/src/hc/cli.zig
@@ -327,33 +327,12 @@ const numeric_option_short = [_]u8{ 'z', 'q', 'n', 'x', 'T' };
 /// Long names of options that take a numeric value.
 const numeric_option_long = [_][]const u8{ "limit", "offset", "min", "max", "threads" };
 
-/// True when `tok` is a bare value-expecting option token with no attached
-/// value (e.g. `-s` or `--source` but not `-s=x` or `-sx`).
-pub fn isBareValueOption(tok: []const u8) bool {
-    if (tok.len == 2 and tok[0] == '-') {
-        for (value_option_short) |c| if (tok[1] == c) return true;
-        return false;
-    }
-    if (std.mem.startsWith(u8, tok, "--") and std.mem.indexOfScalar(u8, tok, '=') == null) {
-        const name = tok[2..];
-        for (value_option_long) |n| if (std.mem.eql(u8, name, n)) return true;
-        return false;
-    }
-    return false;
+fn isBareValueOption(tok: []const u8) bool {
+    return lib.isBareNamedOption(tok, &value_option_short, &value_option_long);
 }
 
-/// True when `tok` is a bare numeric-value option (limit/offset/min/max/threads).
-pub fn isNumericValueOption(tok: []const u8) bool {
-    if (tok.len == 2 and tok[0] == '-') {
-        for (numeric_option_short) |c| if (tok[1] == c) return true;
-        return false;
-    }
-    if (std.mem.startsWith(u8, tok, "--") and std.mem.indexOfScalar(u8, tok, '=') == null) {
-        const name = tok[2..];
-        for (numeric_option_long) |n| if (std.mem.eql(u8, name, n)) return true;
-        return false;
-    }
-    return false;
+fn isNumericValueOption(tok: []const u8) bool {
+    return lib.isBareNamedOption(tok, &numeric_option_short, &numeric_option_long);
 }
 
 /// yazap's tokenizer skips empty argv elements and treats `-10` as a short

--- a/src/hc/lib.zig
+++ b/src/hc/lib.zig
@@ -157,6 +157,11 @@ const yazap_util = @import("yazap_util.zig");
 pub const YazapStdoutRedirect = yazap_util.YazapStdoutRedirect;
 pub const normalizeArgv = yazap_util.normalizeArgv;
 pub const isNegativeNumber = yazap_util.isNegativeNumber;
+pub const isBareNamedOption = yazap_util.isBareNamedOption;
+
+test {
+    _ = yazap_util;
+}
 
 pub fn startTimer(io: std.Io) void {
     timer_start = std.Io.Clock.awake.now(io);

--- a/src/hc/yazap_util.zig
+++ b/src/hc/yazap_util.zig
@@ -15,6 +15,21 @@ pub fn isNegativeNumber(tok: []const u8) bool {
     return true;
 }
 
+/// True when `tok` is a bare value-expecting option with no attached value
+/// (e.g. `-s` / `--source`, but not `-s=x` or `-sx`).
+pub fn isBareNamedOption(tok: []const u8, shorts: []const u8, longs: []const []const u8) bool {
+    if (tok.len == 2 and tok[0] == '-') {
+        for (shorts) |c| if (tok[1] == c) return true;
+        return false;
+    }
+    if (std.mem.startsWith(u8, tok, "--") and std.mem.indexOfScalar(u8, tok, '=') == null) {
+        const name = tok[2..];
+        for (longs) |n| if (std.mem.eql(u8, name, n)) return true;
+        return false;
+    }
+    return false;
+}
+
 fn attachValue(
     allocator: std.mem.Allocator,
     opt_tok: []const u8,
@@ -98,3 +113,14 @@ pub const YazapStdoutRedirect = struct {
         }
     }
 };
+
+test "isBareNamedOption matches short and long forms" {
+    const shorts = [_]u8{ 'q', 'f' };
+    const longs = [_][]const u8{ "query", "file" };
+    try std.testing.expect(isBareNamedOption("-q", &shorts, &longs));
+    try std.testing.expect(isBareNamedOption("--query", &shorts, &longs));
+    try std.testing.expect(!isBareNamedOption("-q=x", &shorts, &longs));
+    try std.testing.expect(!isBareNamedOption("-qx", &shorts, &longs));
+    try std.testing.expect(!isBareNamedOption("--query=x", &shorts, &longs));
+    try std.testing.expect(!isBareNamedOption("-z", &shorts, &longs));
+}

--- a/src/l2h/cli.zig
+++ b/src/l2h/cli.zig
@@ -76,25 +76,10 @@ const value_option_short = [_]u8{ 'q', 'f' };
 /// Long names of options that take a value.
 const value_option_long = [_][]const u8{ "query", "file" };
 
-/// True when `tok` is a bare value-expecting option token with no attached
-/// value (e.g. `-q` or `--query` but not `-q=x` or `-qx`).
-fn isBareValueOption(tok: []const u8) bool {
-    if (tok.len == 2 and tok[0] == '-') {
-        for (value_option_short) |c| if (tok[1] == c) return true;
-        return false;
-    }
-    if (std.mem.startsWith(u8, tok, "--") and std.mem.indexOfScalar(u8, tok, '=') == null) {
-        const name = tok[2..];
-        for (value_option_long) |n| if (std.mem.eql(u8, name, n)) return true;
-        return false;
-    }
-    return false;
-}
-
 fn shouldAttach(opt_tok: []const u8, next_tok: []const u8) bool {
     // yazap skips empty argv elements; rewrite `-q ""` into `-q=` so an empty
     // query is captured (same approach as hc's normalizeArgv).
-    return isBareValueOption(opt_tok) and next_tok.len == 0;
+    return lib.isBareNamedOption(opt_tok, &value_option_short, &value_option_long) and next_tok.len == 0;
 }
 
 fn inputFromMatches(matches: ArgMatches) Input {


### PR DESCRIPTION
Probe hex now matches modes.types.hashToHex upper-case formatting.