### PR TITLE
feat(l2h): Dir.skipErrors() and File.readable for soft I/O

### DIFF
--- a/docs/l2h-semantics.md
+++ b/docs/l2h-semantics.md
@@ -214,6 +214,7 @@ Which properties are available depends entirely on the **runtime kind** of the r
 | `File` | `size` | `Int` | File size in bytes (full file; unaffected by `limit`/`offset`) |
 | `File` | `offset` | `Int` | Start position in bytes for hashing (default `0`). **Window bind** in `where` — see §4.5 |
 | `File` | `limit` | `Int` | Max bytes to hash from `offset` (default: whole file). **Window bind** in `where` — see §4.5 |
+| `File` | `readable` | `Bool` | `true` if the path opens as a regular file (probe open+stat); `false` on permission/missing/non-file — never raises I/O. Use `where f.readable` before `size` / `<hash>` |
 | `File` | `<hash>` | `String` | Hex digest of file contents (honoring the bound window); `<hash>` can be any algorithm name `hc` knows (`md5`, `sha1`, `tiger`, …) |
 | `String` | `size` | `Int` | Length in bytes (UTF-8 payload length as stored) |
 | `String` | `<hash>` | `String` | Hex digest of the string's bytes |
@@ -270,6 +271,7 @@ Reading `f.limit` / `f.offset` outside a bind — say, in `select` — just give
 | `d.tree()` | unlimited | Walk the whole tree under `d` |
 | `d.tree(n)` | `n` (`Int`, `n ≥ 0`) | Include files whose relative directory depth is at most `n` |
 | `d.tree(0)` | `0` | Same as flat `from file f in d` — only the current directory |
+| `d.skipErrors()` | (unchanged) | Soft walk: skip subdirectories that cannot be entered |
 
 Depth counts how many directory levels below `d` you may enter: `tree(1)` yields files in `d` plus files in immediate subdirectories, but not deeper. Leave the bare `d` alone and `from file f in d` only sees files sitting in that folder; pass a `tree` result and the same `from` walks according to the limit:
 
@@ -285,7 +287,17 @@ from file f in d.tree(1)
 select f.path;
 ```
 
-The original `d` is not mutated — you can still use `from file f in d` for a flat listing in the same query. Symlinks stay skipped even while recursing — same as flat listing, and same as `hc -r`. Calling `tree` on a non-`Dir`, with a non-`Int` argument, with more than one argument, or with a negative depth is an error. There is no `tree` property; bare `d.tree` (without `()`) is an invalid property.
+The original `d` is not mutated — you can still use `from file f in d` for a flat listing in the same query. Symlinks stay skipped even while recursing — same as flat listing, and same as `hc -r`.
+
+**Unreadable subdirectories.** By default, failing to enter a subdirectory during a recursive walk is an **I/O error** (the query stops; the message includes the directory path). `skipErrors()` returns a **new** `Dir` that skips such directories and continues with siblings:
+
+```text
+from dir d in '/tmp'
+from file f in d.tree().skipErrors()
+select f.path;
+```
+
+`tree` / `tree(n)` and `skipErrors()` compose in either order — each copies the other's flags onto the new `Dir`. Calling `tree` / `skipErrors` on a non-`Dir`, wrong arity/types, or a negative tree depth is an error. There is no `tree` / `skipErrors` property; bare `d.tree` / `d.skipErrors` without `()` is an invalid property.
 
 ### 4.7 Record methods (formatters)
 
@@ -375,7 +387,7 @@ Inside clauses you write expressions, and the supported forms are:
 - A range identifier on its own
 - Property access `id.prop`
 - Method call `id.method(args…)` or `{…}.method(args…)` — Record formatters §4.7, hash-check on `File`/`String` §4.8, or `Dir.tree()` §4.6 (hash-check needs a bound `File`/`String` identifier — you can't call it on a bare literal record)
-- Bool-typed expressions as bare `where` predicates (hash-check methods, `let`-bound `Bool`, nested-query exists)
+- Bool-typed expressions as bare `where` predicates (hash-check methods, `f.readable`, `let`-bound `Bool`, nested-query exists)
 - Relational operators: `==`, `!=`, `>`, `>=`, `<`, `<=`, `~`, `!~`
 - Boolean operators: `&&`, `||`, `!`, and parentheses
 - Anonymous objects: `{ e1, e2, … }` and `{ name = e, … }` → `Record` (§5.4)
@@ -540,8 +552,8 @@ There's no global `sources` tape here, and nothing coupled to an instruction ind
 | Compile-time check / IR | `compile.zig` |
 | LINQ clauses | `from`, `where`, `let`, `join`, `join … into`, `orderby`, `group by`, `select`, `into` |
 | Properties | Demand-driven catalog in `props.zig` (§4.3) |
-| Methods | Catalog + formatters in `method.zig` — §4.7 formatters; §4.8 hash-check; §4.6 `Dir.tree` (`arityRange`) |
-| Recursive dir walk | Yes — `from file f in d.tree()` / `d.tree(n)` (§3.4 / §4.6) |
+| Methods | Catalog + formatters in `method.zig` — §4.7 formatters; §4.8 hash-check; §4.6 `Dir.tree` / `Dir.skipErrors` (`arityRange`) |
+| Recursive dir walk | Yes — `from file f in d.tree()` / `d.tree(n)` / `d.skipErrors()` (§3.4 / §4.6) |
 
 **Known limitations**: some mixed/`unknown` sequence shapes and I/O failures only get detected at runtime, not statically.
 
@@ -562,7 +574,7 @@ This section exists to explain why the behavior is what it is — it's reference
 | `group proj by key` element | Record `{ key, items }` where `items` is the sequence of grouped elements |
 | File `limit` / `offset` | Bound via `==` in `where` only meaningfully; unbound `limit` reads as `maxInt(i64)`; applies to subsequent file hashes like `hc` (§4.5) |
 | `~` / `!~` operands | Both **`String`** (subject ~ pattern); no stringify (§5.2) |
-| Dir `tree` | Method on `Dir`: `tree()` unlimited, `tree(n)` depth-limited (`tree(0)` ≡ flat); use as `from file f in d.tree(…)`; never follows symlinks (§4.6) |
+| Dir `tree` / `skipErrors` | `tree()` unlimited, `tree(n)` depth-limited (`tree(0)` ≡ flat); `skipErrors()` soft-skips unreadable subdirs; compose freely; never follows symlinks (§4.6) |
 | Boolean literals | `true` / `false` work as values and as bare predicates (§5.2) |
 | Bare bool predicates | Hash-check / `let`-bound `Bool` / nested-query exists are valid `where` predicates (§5.2) |
 | Record methods | Formatters only on `Record`; return `String`; lowercase names like properties (§4.7) |

--- a/docs/l2h-semantics.md
+++ b/docs/l2h-semantics.md
@@ -75,7 +75,7 @@ from file f in d.tree()
 where f.size > 1000
 select f.sha1;
 ```
-`d.tree()` returns a new `Dir` with recursion turned on; feed that into `from file` and you get the whole tree (§4.6). The original `d` is unchanged — `from file f in d` still means flat.
+`d.tree()` returns a new `Dir` that walks without a depth limit; feed that into `from file` and you get the whole tree (§4.6). `d.tree(n)` limits descent to `n` levels (`tree(0)` is the same as flat). The original `d` is unchanged — `from file f in d` still means flat.
 
 **Join two sources on equal digests:**
 ```text
@@ -165,9 +165,9 @@ Any additional `from` in the body works like a **SelectMany**: for each outer ro
 
 When `from file f in <Dir>` walks a directory, a few rules apply:
 
-- **Flat by default.** Only the files sitting directly in that folder get visited. If you want the whole tree, pass `d.tree()` instead of `d` (§4.6).
-- **Regular files only.** Symlinks are always skipped — whether they point at a file or a directory. Flat mode also skips subdirectories entirely; recursive mode descends into real directories but still ignores symlink entries (it never follows them).
-- **No magic recursive `from dir`.** Recursion is a flag on the `Dir` value, flipped by the `tree()` method — not a separate source form of its own.
+- **Flat by default.** Only the files sitting directly in that folder get visited. If you want more, pass `d.tree()` (unlimited) or `d.tree(n)` (depth-limited) instead of `d` (§4.6).
+- **Regular files only.** Symlinks are always skipped — whether they point at a file or a directory. Flat mode also skips subdirectories entirely; recursive modes descend into real directories but still ignore symlink entries (they never follow them).
+- **No magic recursive `from dir`.** Recursion is a depth limit on the `Dir` value, set by the `tree` method — not a separate source form of its own.
 
 Order is technically implementation-defined, but for a given filesystem snapshot it's stable: lexicographic by full path (see the tests for the exact behavior).
 
@@ -218,7 +218,7 @@ Which properties are available depends entirely on the **runtime kind** of the r
 | `String` | `size` | `Int` | Length in bytes (UTF-8 payload length as stored) |
 | `String` | `<hash>` | `String` | Hex digest of the string's bytes |
 | `Hash` | `<hash>` | `String` | **Restore** path: treats the bound digest as the input digest for algorithm `<hash>` (same meaning as legacy `from hash … select x.md5`) — this is *not* "hash the digest characters as a string" |
-| `Dir` | `path` | `String` | Path identifying the directory (no I/O; projects the bound path). Use `from file f in d` (or `d.tree()`) to reach the files inside |
+| `Dir` | `path` | `String` | Path identifying the directory (no I/O; projects the bound path). Use `from file f in d` (or `d.tree()` / `d.tree(n)`) to reach the files inside |
 | `Record` | field name | field value | Fields introduced by `{…}`, `let`, or join shaping |
 | `Int` / `Bool` / `Seq` | — | — | No properties in v1.0 |
 
@@ -261,9 +261,17 @@ select f.md5;
 
 Reading `f.limit` / `f.offset` outside a bind — say, in `select` — just gives you the currently bound integers (defaults, if they were never bound). So an unbound `select f.limit` yields `maxInt(i64)`, not a special "EOF" token. That's allowed but rarely what you'd actually want; the useful place for these is inside `where`.
 
-### 4.6 Directory recursion (`Dir.tree()`)
+### 4.6 Directory recursion (`Dir.tree()` / `Dir.tree(n)`)
 
-`tree()` is a **`Dir`-only** method with no arguments. It returns a **new** `Dir` with the same path and the recursive-enumeration flag set. Leave it alone and `from file f in d` only sees files sitting in that folder; pass the method result and the same `from` walks the whole tree:
+`tree` is a **`Dir`-only** method. It returns a **new** `Dir` with the same path and a depth limit for enumeration:
+
+| Call | Depth | Effect |
+|------|-------|--------|
+| `d.tree()` | unlimited | Walk the whole tree under `d` |
+| `d.tree(n)` | `n` (`Int`, `n ≥ 0`) | Include files whose relative directory depth is at most `n` |
+| `d.tree(0)` | `0` | Same as flat `from file f in d` — only the current directory |
+
+Depth counts how many directory levels below `d` you may enter: `tree(1)` yields files in `d` plus files in immediate subdirectories, but not deeper. Leave the bare `d` alone and `from file f in d` only sees files sitting in that folder; pass a `tree` result and the same `from` walks according to the limit:
 
 ```text
 from dir d in '/tmp'
@@ -271,7 +279,13 @@ from file f in d.tree()
 select f.path;
 ```
 
-The original `d` is not mutated — you can still use `from file f in d` for a flat listing in the same query. Symlinks stay skipped even while recursing — same as flat listing, and same as `hc -r`. Calling `tree()` on a non-`Dir`, or with any arguments, is an error. There is no `tree` property; bare `d.tree` (without `()`) is an invalid property.
+```text
+from dir d in '/tmp'
+from file f in d.tree(1)
+select f.path;
+```
+
+The original `d` is not mutated — you can still use `from file f in d` for a flat listing in the same query. Symlinks stay skipped even while recursing — same as flat listing, and same as `hc -r`. Calling `tree` on a non-`Dir`, with a non-`Int` argument, with more than one argument, or with a negative depth is an error. There is no `tree` property; bare `d.tree` (without `()`) is an invalid property.
 
 ### 4.7 Record methods (formatters)
 
@@ -357,7 +371,7 @@ You can put multiple queries in one translation unit, separated by semicolons. C
 
 Inside clauses you write expressions, and the supported forms are:
 
-- String, integer, and boolean literals — including bare `true` / `false` in `where` and `select`
+- String, integer, and boolean literals — including bare `true` / `false` in `where` and `select`, and signed integer literals like `-1`
 - A range identifier on its own
 - Property access `id.prop`
 - Method call `id.method(args…)` or `{…}.method(args…)` — Record formatters §4.7, hash-check on `File`/`String` §4.8, or `Dir.tree()` §4.6 (hash-check needs a bound `File`/`String` identifier — you can't call it on a bare literal record)
@@ -526,8 +540,8 @@ There's no global `sources` tape here, and nothing coupled to an instruction ind
 | Compile-time check / IR | `compile.zig` |
 | LINQ clauses | `from`, `where`, `let`, `join`, `join … into`, `orderby`, `group by`, `select`, `into` |
 | Properties | Demand-driven catalog in `props.zig` (§4.3) |
-| Methods | Catalog + formatters in `method.zig` — §4.7 formatters; §4.8 hash-check; §4.6 `Dir.tree()` |
-| Recursive dir walk | Yes — `from file f in d.tree()` (§3.4 / §4.6) |
+| Methods | Catalog + formatters in `method.zig` — §4.7 formatters; §4.8 hash-check; §4.6 `Dir.tree` (`arityRange`) |
+| Recursive dir walk | Yes — `from file f in d.tree()` / `d.tree(n)` (§3.4 / §4.6) |
 
 **Known limitations**: some mixed/`unknown` sequence shapes and I/O failures only get detected at runtime, not statically.
 
@@ -548,7 +562,7 @@ This section exists to explain why the behavior is what it is — it's reference
 | `group proj by key` element | Record `{ key, items }` where `items` is the sequence of grouped elements |
 | File `limit` / `offset` | Bound via `==` in `where` only meaningfully; unbound `limit` reads as `maxInt(i64)`; applies to subsequent file hashes like `hc` (§4.5) |
 | `~` / `!~` operands | Both **`String`** (subject ~ pattern); no stringify (§5.2) |
-| Dir `tree()` | Method on `Dir` returns a new Dir with recursion on; use as `from file f in d.tree()` (§4.6); never follows symlinks |
+| Dir `tree` | Method on `Dir`: `tree()` unlimited, `tree(n)` depth-limited (`tree(0)` ≡ flat); use as `from file f in d.tree(…)`; never follows symlinks (§4.6) |
 | Boolean literals | `true` / `false` work as values and as bare predicates (§5.2) |
 | Bare bool predicates | Hash-check / `let`-bound `Bool` / nested-query exists are valid `where` predicates (§5.2) |
 | Record methods | Formatters only on `Record`; return `String`; lowercase names like properties (§4.7) |

--- a/src/l2h/compile.zig
+++ b/src/l2h/compile.zig
@@ -666,7 +666,7 @@ fn inferExprType(
         },
         .method => |m| blk: {
             const kind = method.lookup(m.name) orelse return fail(e.span, error.UnknownMethod);
-            if (m.args.len != method.arity(kind)) return fail(e.span, error.InvalidMethodArity);
+            if (!method.arityOk(kind, m.args.len)) return fail(e.span, error.InvalidMethodArity);
 
             const recv_ty = try inferExprType(allocator, scope, m.recv, depth);
             switch (kind) {
@@ -707,6 +707,10 @@ fn inferExprType(
                     switch (recv_ty) {
                         .dir, .unknown => {},
                         else => return fail(e.span, error.InvalidMethodReceiver),
+                    }
+                    if (m.args.len == 1) {
+                        const arg_ty = try inferExprType(allocator, scope, m.args[0], depth);
+                        if (arg_ty != .int and arg_ty != .unknown) return fail(e.span, error.TypeMismatch);
                     }
                 },
             }

--- a/src/l2h/compile.zig
+++ b/src/l2h/compile.zig
@@ -713,6 +713,12 @@ fn inferExprType(
                         if (arg_ty != .int and arg_ty != .unknown) return fail(e.span, error.TypeMismatch);
                     }
                 },
+                .dir_skip_errors => {
+                    switch (recv_ty) {
+                        .dir, .unknown => {},
+                        else => return fail(e.span, error.InvalidMethodReceiver),
+                    }
+                },
             }
 
             break :blk typeFromResultTag(method.resultKind(kind));

--- a/src/l2h/compile_test.zig
+++ b/src/l2h/compile_test.zig
@@ -547,7 +547,10 @@ test "compile+run from file in string variable opens as path" {
     const got = try runQuery(query);
 
     // Assert — 'abc' is not an existing regular file
-    try std.testing.expectEqualStrings("I/O failure (missing path or unreadable file/directory)", got.err);
+    try std.testing.expectEqualStrings(
+        "I/O failure (missing path or unreadable file/directory): abc",
+        got.err,
+    );
 }
 
 test "compile+run select into continuation rejects outer name" {
@@ -569,7 +572,10 @@ test "compile+run missing file reports io failure" {
     const got = try runQuery(query);
 
     // Assert
-    try std.testing.expectEqualStrings("I/O failure (missing path or unreadable file/directory)", got.err);
+    try std.testing.expectEqualStrings(
+        "I/O failure (missing path or unreadable file/directory): /definitely-missing-l2h-test-path",
+        got.err,
+    );
     // Path literal in `from file f in '…'`
     try std.testing.expectEqual(@as(c_int, 1), diag.last_span.first_line);
     try std.testing.expectEqual(@as(c_int, 16), diag.last_span.first_column);
@@ -883,7 +889,7 @@ test "compile+run dir.tree property access is invalid" {
     try std.testing.expectEqualStrings("invalid property for this value type", got.err);
 }
 
-test "compile+run dir.tree with args is arity error" {
+test "compile+run dir.tree(true) is type mismatch" {
     // Arrange
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -894,6 +900,116 @@ test "compile+run dir.tree with args is arity error" {
     const query = try std.fmt.allocPrint(
         std.testing.allocator,
         "from dir d in '{s}' from file f in d.tree(true) select f.path;",
+        .{dir_path},
+    );
+    defer std.testing.allocator.free(query);
+
+    // Act
+    const got = try runQuery(query);
+
+    // Assert
+    try std.testing.expectEqualStrings("type mismatch in expression or clause", got.err);
+}
+
+test "compile+run dir.tree(0) matches flat listing" {
+    // Arrange
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.writeFile(state.io, .{ .sub_path = "top.txt", .data = "t" });
+    try tmp.dir.createDir(state.io, "sub", std.Io.Dir.Permissions.default_dir);
+    try tmp.dir.writeFile(state.io, .{ .sub_path = "sub/nested.txt", .data = "nn" });
+
+    const dir_path = try tmpQueryPath(std.testing.allocator, tmp);
+    defer std.testing.allocator.free(dir_path);
+
+    const query = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "from dir d in '{s}' from file f in d.tree(0) orderby f.size select f.size;",
+        .{dir_path},
+    );
+    defer std.testing.allocator.free(query);
+
+    // Act
+    const got = try runQuery(query);
+
+    // Assert — nested file excluded
+    try std.testing.expectEqualStrings("1\n", got.out);
+    try std.testing.expectEqualStrings("", got.err);
+}
+
+test "compile+run dir.tree(1) stops after one subdirectory level" {
+    // Arrange — root / one / two levels deep
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.writeFile(state.io, .{ .sub_path = "top.txt", .data = "t" });
+    try tmp.dir.createDir(state.io, "sub", std.Io.Dir.Permissions.default_dir);
+    try tmp.dir.writeFile(state.io, .{ .sub_path = "sub/mid.txt", .data = "mm" });
+    try tmp.dir.createDir(state.io, "sub/deep", std.Io.Dir.Permissions.default_dir);
+    try tmp.dir.writeFile(state.io, .{ .sub_path = "sub/deep/bot.txt", .data = "bbb" });
+
+    const dir_path = try tmpQueryPath(std.testing.allocator, tmp);
+    defer std.testing.allocator.free(dir_path);
+
+    const q1 = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "from dir d in '{s}' from file f in d.tree(1) orderby f.size select f.size;",
+        .{dir_path},
+    );
+    defer std.testing.allocator.free(q1);
+
+    const q2 = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "from dir d in '{s}' from file f in d.tree(2) orderby f.size select f.size;",
+        .{dir_path},
+    );
+    defer std.testing.allocator.free(q2);
+
+    // Act
+    const got1 = try runQuery(q1);
+    const got2 = try runQuery(q2);
+
+    // Assert — tree(1): top(1) + mid(2); tree(2): also bot(3)
+    try std.testing.expectEqualStrings("1\n2\n", got1.out);
+    try std.testing.expectEqualStrings("", got1.err);
+    try std.testing.expectEqualStrings("1\n2\n3\n", got2.out);
+    try std.testing.expectEqualStrings("", got2.err);
+}
+
+test "compile+run dir.tree(-1) is invalid tree depth" {
+    // Arrange
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const dir_path = try tmpQueryPath(std.testing.allocator, tmp);
+    defer std.testing.allocator.free(dir_path);
+
+    const query = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "from dir d in '{s}' from file f in d.tree(-1) select f.path;",
+        .{dir_path},
+    );
+    defer std.testing.allocator.free(query);
+
+    // Act
+    const got = try runQuery(query);
+
+    // Assert
+    try std.testing.expectEqualStrings("tree depth must be non-negative", got.err);
+}
+
+test "compile+run dir.tree two args is arity error" {
+    // Arrange
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const dir_path = try tmpQueryPath(std.testing.allocator, tmp);
+    defer std.testing.allocator.free(dir_path);
+
+    const query = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "from dir d in '{s}' from file f in d.tree(1, 2) select f.path;",
         .{dir_path},
     );
     defer std.testing.allocator.free(query);
@@ -1153,7 +1269,13 @@ test "compile+run from file rejects directory path" {
     const got = try runQuery(query);
 
     // Assert
-    try std.testing.expectEqualStrings("I/O failure (missing path or unreadable file/directory)", got.err);
+    const expect_err = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "I/O failure (missing path or unreadable file/directory): {s}",
+        .{dir_path},
+    );
+    defer std.testing.allocator.free(expect_err);
+    try std.testing.expectEqualStrings(expect_err, got.err);
 }
 
 test "compile+run from file over int source fails during compilation" {

--- a/src/l2h/compile_test.zig
+++ b/src/l2h/compile_test.zig
@@ -1021,6 +1021,155 @@ test "compile+run dir.tree two args is arity error" {
     try std.testing.expectEqualStrings("wrong number of method arguments", got.err);
 }
 
+test "compile+run dir.tree() without skipErrors fails on unreadable subdir" {
+    if (comptime @import("builtin").os.tag == .windows) return;
+
+    // Arrange
+    var tmp = std.testing.tmpDir(.{});
+    defer {
+        tmp.dir.setFilePermissions(state.io, "denied", .fromMode(0o700), .{}) catch {};
+        tmp.cleanup();
+    }
+
+    try tmp.dir.writeFile(state.io, .{ .sub_path = "ok.txt", .data = "ok" });
+    try tmp.dir.createDir(state.io, "denied", .fromMode(0));
+
+    const dir_path = try tmpQueryPath(std.testing.allocator, tmp);
+    defer std.testing.allocator.free(dir_path);
+
+    const query = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "from dir d in '{s}' from file f in d.tree() select f.path;",
+        .{dir_path},
+    );
+    defer std.testing.allocator.free(query);
+
+    // Act
+    const got = try runQuery(query);
+
+    // Assert
+    try std.testing.expect(std.mem.startsWith(u8, got.err, "I/O failure (missing path or unreadable file/directory):"));
+    try std.testing.expect(std.mem.indexOf(u8, got.err, "denied") != null);
+}
+
+test "compile+run dir.tree().skipErrors() skips unreadable subdir" {
+    if (comptime @import("builtin").os.tag == .windows) return;
+
+    // Arrange
+    var tmp = std.testing.tmpDir(.{});
+    defer {
+        tmp.dir.setFilePermissions(state.io, "denied", .fromMode(0o700), .{}) catch {};
+        tmp.cleanup();
+    }
+
+    try tmp.dir.writeFile(state.io, .{ .sub_path = "ok.txt", .data = "ok" });
+    try tmp.dir.createDir(state.io, "denied", .fromMode(0));
+
+    const dir_path = try tmpQueryPath(std.testing.allocator, tmp);
+    defer std.testing.allocator.free(dir_path);
+
+    const query = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "from dir d in '{s}' from file f in d.tree().skipErrors() select f.name;",
+        .{dir_path},
+    );
+    defer std.testing.allocator.free(query);
+
+    // Act
+    const got = try runQuery(query);
+
+    // Assert
+    try std.testing.expectEqualStrings("ok.txt\n", got.out);
+    try std.testing.expectEqualStrings("", got.err);
+}
+
+test "compile+run skipErrors().tree() composes flags" {
+    if (comptime @import("builtin").os.tag == .windows) return;
+
+    // Arrange
+    var tmp = std.testing.tmpDir(.{});
+    defer {
+        tmp.dir.setFilePermissions(state.io, "denied", .fromMode(0o700), .{}) catch {};
+        tmp.cleanup();
+    }
+
+    try tmp.dir.writeFile(state.io, .{ .sub_path = "ok.txt", .data = "ok" });
+    try tmp.dir.createDir(state.io, "denied", .fromMode(0));
+
+    const dir_path = try tmpQueryPath(std.testing.allocator, tmp);
+    defer std.testing.allocator.free(dir_path);
+
+    const query = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "from dir d in '{s}' from file f in d.skipErrors().tree() select f.name;",
+        .{dir_path},
+    );
+    defer std.testing.allocator.free(query);
+
+    // Act
+    const got = try runQuery(query);
+
+    // Assert
+    try std.testing.expectEqualStrings("ok.txt\n", got.out);
+    try std.testing.expectEqualStrings("", got.err);
+}
+
+test "compile+run where f.readable filters unreadable files" {
+    if (comptime @import("builtin").os.tag == .windows) return;
+
+    // Arrange
+    var tmp = std.testing.tmpDir(.{});
+    defer {
+        tmp.dir.setFilePermissions(state.io, "locked.txt", .fromMode(0o644), .{}) catch {};
+        tmp.cleanup();
+    }
+
+    try tmp.dir.writeFile(state.io, .{ .sub_path = "ok.txt", .data = "ok" });
+    try tmp.dir.writeFile(state.io, .{ .sub_path = "locked.txt", .data = "secret" });
+    try tmp.dir.setFilePermissions(state.io, "locked.txt", .fromMode(0), .{});
+
+    const dir_path = try tmpQueryPath(std.testing.allocator, tmp);
+    defer std.testing.allocator.free(dir_path);
+
+    const query = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "from dir d in '{s}' from file f in d where f.readable select f.name;",
+        .{dir_path},
+    );
+    defer std.testing.allocator.free(query);
+
+    // Act
+    const got = try runQuery(query);
+
+    // Assert
+    try std.testing.expectEqualStrings("ok.txt\n", got.out);
+    try std.testing.expectEqualStrings("", got.err);
+}
+
+test "compile+run file.readable is a valid bare where predicate" {
+    // Arrange
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(state.io, .{ .sub_path = "a.txt", .data = "a" });
+
+    const dir_path = try tmpQueryPath(std.testing.allocator, tmp);
+    defer std.testing.allocator.free(dir_path);
+
+    const query = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "from dir d in '{s}' from file f in d where f.readable select f.size;",
+        .{dir_path},
+    );
+    defer std.testing.allocator.free(query);
+
+    // Act
+    const got = try runQuery(query);
+
+    // Assert
+    try std.testing.expectEqualStrings("1\n", got.out);
+    try std.testing.expectEqualStrings("", got.err);
+}
+
 test "compile+run file.tree() is invalid method receiver" {
     // Arrange
     const query = "from file f in 'x' select f.tree();";

--- a/src/l2h/diag.zig
+++ b/src/l2h/diag.zig
@@ -6,7 +6,7 @@ const state = @import("state.zig");
 const expr = @import("expr.zig");
 
 /// Plain last diagnostic text for tests (fehler itself always prints to stderr).
-pub var last_message: [512]u8 = undefined;
+pub var last_message: [768]u8 = undefined;
 pub var last_message_len: usize = 0;
 
 /// Last reported source span (for tests).
@@ -15,14 +15,31 @@ pub var last_span: expr.Span = .{};
 /// Pending span for the next `report` (set while compiling/evaluating).
 var pending_span: ?expr.Span = null;
 
+/// Optional filesystem path attached to the next `IoFailure` message.
+var pending_io_path: [512]u8 = undefined;
+var pending_io_path_len: usize = 0;
+
+/// Scratch buffer for `messageForRuntime` when it embeds a path.
+var runtime_msg_buf: [768]u8 = undefined;
+
+pub const IO_FAILURE_MSG = "I/O failure (missing path or unreadable file/directory)";
+
 pub fn clearLast() void {
     last_message_len = 0;
     last_span = .{};
     pending_span = null;
+    pending_io_path_len = 0;
 }
 
 pub fn lastMessage() []const u8 {
     return last_message[0..last_message_len];
+}
+
+/// Remember a path to include in the next `IoFailure` diagnostic.
+pub fn noteIoPath(path: []const u8) void {
+    const n = @min(path.len, pending_io_path.len);
+    @memcpy(pending_io_path[0..n], path[0..n]);
+    pending_io_path_len = n;
 }
 
 pub fn noteSpan(sp: expr.Span) void {
@@ -124,6 +141,7 @@ fn sharedMessage(err: anyerror) ?[]const u8 {
         error.UndefinedName => "undefined name",
         error.QueryTooDeep => "query nesting too deep",
         error.OutOfMemory => "out of memory",
+        error.InvalidTreeDepth => "tree depth must be non-negative",
         else => null,
     };
 }
@@ -144,7 +162,12 @@ pub fn messageForRuntime(err: anyerror) []const u8 {
         error.UnknownProperty => "unknown property",
         error.UnknownHash => "unknown hash algorithm",
         error.InvalidHashDigest => "invalid hash digest for the selected algorithm",
-        error.IoFailure => "I/O failure (missing path or unreadable file/directory)",
+        error.IoFailure => blk: {
+            if (pending_io_path_len == 0) break :blk IO_FAILURE_MSG;
+            const path = pending_io_path[0..pending_io_path_len];
+            pending_io_path_len = 0;
+            break :blk std.fmt.bufPrint(&runtime_msg_buf, "{s}: {s}", .{ IO_FAILURE_MSG, path }) catch IO_FAILURE_MSG;
+        },
         error.WriteFailed => "write failed",
         error.Overflow => "value out of integer range",
         error.InvalidWindow => "limit/offset must be non-negative",

--- a/src/l2h/frontend.zig
+++ b/src/l2h/frontend.zig
@@ -82,6 +82,13 @@ fn createNumberNode(left: ?*c.fend_node_t, right: ?*c.fend_node_t, t: c_int, val
     return node;
 }
 
+/// Integer literal as a unary-wrapped `node_type_numeric_literal`.
+/// Prefer this over smuggling the value through `void*` (breaks for negatives).
+pub export fn fend_on_number_literal(value: c_longlong) ?*c.fend_node_t {
+    const lit = createNumberNode(null, null, c.node_type_numeric_literal, value) orelse return null;
+    return createNode(lit, null, c.node_type_unary_expression);
+}
+
 /// Boolean literal as a unary-wrapped `node_type_boolean_literal` (value 0/1).
 /// Separate from `fend_on_unary_expression` so `false` is not passed as a null void*.
 pub export fn fend_on_boolean_literal(value: c_int) ?*c.fend_node_t {
@@ -383,6 +390,8 @@ test "fend_to_number parses decimal and hex" {
     try std.testing.expectEqual(@as(c_longlong, 255), fend_to_number(@constCast("255".ptr)));
     try std.testing.expectEqual(@as(c_longlong, 0xff), fend_to_number(@constCast("0xff".ptr)));
     try std.testing.expectEqual(@as(c_longlong, 0), fend_to_number(@constCast("not-a-number".ptr)));
+    try std.testing.expectEqual(@as(c_longlong, -1), fend_to_number(@constCast("-1".ptr)));
+    try std.testing.expectEqual(@as(c_longlong, -42), fend_to_number(@constCast("-42".ptr)));
 }
 
 test "fend_on_identifier builds identifier node within a query" {

--- a/src/l2h/grammar/frontend.h
+++ b/src/l2h/grammar/frontend.h
@@ -134,6 +134,7 @@ type_info_t* fend_on_complex_type_def(type_def_t type, char* info);
 type_info_t* fend_on_simple_type_def(type_def_t type);
 fend_node_t* fend_on_identifier_declaration(type_info_t* type, fend_node_t* identifier);
 fend_node_t* fend_on_unary_expression(unary_exp_type_t type, void* leftValue, void* rightValue);
+fend_node_t* fend_on_number_literal(long long value);
 fend_node_t* fend_on_boolean_literal(int value);
 fend_node_t* fend_on_from(fend_node_t* type, fend_node_t* datasource);
 fend_node_t* fend_on_where(fend_node_t* expr);

--- a/src/l2h/grammar/l2h.lex
+++ b/src/l2h/grammar/l2h.lex
@@ -133,6 +133,7 @@ ENDL [\r\n]
 
 {IDENTIFIER} { yylval.string = fend_query_strdup(yytext); return IDENTIFIER; }
 {DIGIT}+ { yylval.number = fend_to_number(yytext); return INTEGER; }
+-{DIGIT}+ { yylval.number = fend_to_number(yytext); return INTEGER; }
 {STRING} { yylval.string = fend_query_strdup(yytext); return STRING; }
 
 .  { yylval.string = fend_query_strdup(yytext); return INVALID_STRING; }

--- a/src/l2h/grammar/l2h.y
+++ b/src/l2h/grammar/l2h.y
@@ -85,6 +85,7 @@
 %type <node> expression
 %type <node> value_expression
 %type <node> unary_expression
+%type <node> primary_expression
 %type <node> relational_expr
 %type <node> boolean_expression
 %type <node> conditional_or_expression
@@ -271,9 +272,25 @@ value_expression
 	;
 	
 unary_expression
+	: primary_expression
+	| unary_expression DOT attribute {
+		if ($1 != NULL && $1->type == node_type_unary_expression && $1->left != NULL && $1->right == NULL
+			&& $1->left->type == node_type_identifier
+			&& !fend_is_identifier_defined($1->left))
+			lyyerror(@1, "identifier %s undefined", $1->left->value.string);
+		$$ = fend_on_unary_expression(unary_exp_type_property_call, $1, $3); FLOC($$, @$);
+	}
+	| unary_expression DOT invocation_expression {
+		if ($1 != NULL && $1->type == node_type_unary_expression && $1->left != NULL && $1->right == NULL
+			&& $1->left->type == node_type_identifier
+			&& !fend_is_identifier_defined($1->left))
+			lyyerror(@1, "identifier %s undefined", $1->left->value.string);
+		$$ = fend_on_unary_expression(unary_exp_type_mehtod_call, $1, $3); FLOC($$, @$);
+	}
+	;
+
+primary_expression
 	: identifier { $$ = fend_on_unary_expression(unary_exp_type_identifier, $1, NULL); FLOC($$, @$); }
-	| identifier DOT attribute { if (!fend_is_identifier_defined($1)) lyyerror(@1,"identifier %s undefined", $1->value.string); $$ = fend_on_unary_expression(unary_exp_type_property_call, $1, $3); FLOC($$, @$); }
-	| identifier DOT invocation_expression { if (!fend_is_identifier_defined($1)) lyyerror(@1,"identifier %s undefined", $1->value.string); $$ = fend_on_unary_expression(unary_exp_type_mehtod_call, $1, $3); FLOC($$, @$); }
 	| STRING { $$ = fend_on_unary_expression(unary_exp_type_string, $1, NULL); FLOC($$, @$); }
 	| INTEGER { $$ = fend_on_number_literal($1); FLOC($$, @$); }
 	| BOOL_TRUE { $$ = fend_on_boolean_literal(1); FLOC($$, @$); }

--- a/src/l2h/grammar/l2h.y
+++ b/src/l2h/grammar/l2h.y
@@ -275,7 +275,7 @@ unary_expression
 	| identifier DOT attribute { if (!fend_is_identifier_defined($1)) lyyerror(@1,"identifier %s undefined", $1->value.string); $$ = fend_on_unary_expression(unary_exp_type_property_call, $1, $3); FLOC($$, @$); }
 	| identifier DOT invocation_expression { if (!fend_is_identifier_defined($1)) lyyerror(@1,"identifier %s undefined", $1->value.string); $$ = fend_on_unary_expression(unary_exp_type_mehtod_call, $1, $3); FLOC($$, @$); }
 	| STRING { $$ = fend_on_unary_expression(unary_exp_type_string, $1, NULL); FLOC($$, @$); }
-	| INTEGER { $$ = fend_on_unary_expression(unary_exp_type_number, (void*)$1, NULL); FLOC($$, @$); }
+	| INTEGER { $$ = fend_on_number_literal($1); FLOC($$, @$); }
 	| BOOL_TRUE { $$ = fend_on_boolean_literal(1); FLOC($$, @$); }
 	| BOOL_FALSE { $$ = fend_on_boolean_literal(0); FLOC($$, @$); }
 	;

--- a/src/l2h/interpret.zig
+++ b/src/l2h/interpret.zig
@@ -117,6 +117,13 @@ fn fileSize(ctx: Ctx, path: []const u8) Error!i64 {
     return std.math.cast(i64, st.size) orelse return error.Overflow;
 }
 
+fn fileIsReadable(ctx: Ctx, path: []const u8) bool {
+    var file = std.Io.Dir.cwd().openFile(ctx.io, path, .{}) catch return false;
+    defer file.close(ctx.io);
+    const st = file.stat(ctx.io) catch return false;
+    return st.kind == .file;
+}
+
 /// Demand-driven property access (semantics §4).
 pub fn evalProp(ctx: Ctx, recv: Value, prop: []const u8, sp: expr.Span) Error!Value {
     if (recv == .record) {
@@ -145,6 +152,10 @@ pub fn evalProp(ctx: Ctx, recv: Value, prop: []const u8, sp: expr.Span) Error!Va
         },
         .limit => switch (recv) {
             .file => |f| .{ .int = f.limit },
+            else => unreachable,
+        },
+        .readable => switch (recv) {
+            .file => |f| .{ .bool = fileIsReadable(ctx, f.path) },
             else => unreachable,
         },
         .hash_algo => switch (recv) {
@@ -348,7 +359,20 @@ pub fn evalExpr(ctx: Ctx, e: *const Expr, env: *Env, depth: u32) Error!Value {
                         if (arg_v.int < 0) return failExpr(e, error.InvalidTreeDepth);
                         break :blk std.math.cast(u32, arg_v.int) orelse return failExpr(e, error.Overflow);
                     };
-                    return .{ .dir = .{ .path = recv.dir.path, .max_depth = max_depth } };
+                    return .{ .dir = .{
+                        .path = recv.dir.path,
+                        .max_depth = max_depth,
+                        .skip_errors = recv.dir.skip_errors,
+                    } };
+                },
+                .dir_skip_errors => {
+                    const recv = try evalExpr(ctx, m.recv, env, depth);
+                    if (recv != .dir) return failExpr(e, error.InvalidMethodReceiver);
+                    return .{ .dir = .{
+                        .path = recv.dir.path,
+                        .max_depth = recv.dir.max_depth,
+                        .skip_errors = true,
+                    } };
                 },
             }
         },
@@ -503,13 +527,20 @@ fn listFilesInDir(ctx: Ctx, dir: value.DirVal) Error![]Value {
         var walker = root.walkSelectively(ctx.allocator) catch return error.OutOfMemory;
         defer walker.deinit();
         while (true) {
-            const maybe = walker.next(ctx.io) catch return ioFail(dir.path);
+            const maybe = walker.next(ctx.io) catch {
+                if (dir.skip_errors) continue;
+                return ioFail(dir.path);
+            };
             const entry = maybe orelse break;
             if (entry.kind == .directory) {
                 const unlimited = dir.max_depth == null;
                 const within = if (dir.max_depth) |n| entry.depth() <= n else false;
                 if (unlimited or within) {
-                    walker.enter(ctx.io, entry) catch continue;
+                    walker.enter(ctx.io, entry) catch {
+                        if (dir.skip_errors) continue;
+                        const full = try std.fs.path.join(ctx.allocator, &.{ dir.path, entry.path });
+                        return ioFail(full);
+                    };
                 }
                 continue;
             }

--- a/src/l2h/interpret.zig
+++ b/src/l2h/interpret.zig
@@ -37,6 +37,8 @@ pub const Error = error{
     QueryTooDeep,
     /// Negative limit/offset bind (§4.5).
     InvalidWindow,
+    /// Negative `tree(n)` depth (§4.6).
+    InvalidTreeDepth,
 } || std.mem.Allocator.Error;
 
 pub const Ctx = struct {
@@ -57,6 +59,11 @@ fn failExpr(e: *const Expr, err: Error) Error {
 fn failSpan(sp: expr.Span, err: Error) Error {
     diag.noteSpan(sp);
     return err;
+}
+
+fn ioFail(path: []const u8) Error {
+    diag.noteIoPath(path);
+    return error.IoFailure;
 }
 
 /// Map errors from `modes.hashRun` / `builtinInit` without collapsing digest
@@ -93,18 +100,18 @@ fn hashHexOfFile(ctx: Ctx, algo: []const u8, file: value.FileVal) Error![]const 
         },
         .file_path = file.path,
     };
-    const result = modes.file.calculateFile(file.path, &fctx, runEnv(ctx), def) catch return error.IoFailure;
+    const result = modes.file.calculateFile(file.path, &fctx, runEnv(ctx), def) catch return ioFail(file.path);
     if (result.open_error != null or result.info_error != null or result.hash_error != null or result.offset_error != null)
-        return error.IoFailure;
+        return ioFail(file.path);
     var hex_buf: [modes.types.MAX_DIGEST_SIZE * 2]u8 = undefined;
     const hex = modes.types.hashToHex(result.digest[0..result.digest_len], true, &hex_buf);
     return try ctx.allocator.dupe(u8, hex);
 }
 
 fn fileSize(ctx: Ctx, path: []const u8) Error!i64 {
-    var file = std.Io.Dir.cwd().openFile(ctx.io, path, .{}) catch return error.IoFailure;
+    var file = std.Io.Dir.cwd().openFile(ctx.io, path, .{}) catch return ioFail(path);
     defer file.close(ctx.io);
-    const st = file.stat(ctx.io) catch return error.IoFailure;
+    const st = file.stat(ctx.io) catch return ioFail(path);
     // usize (u64 on 64-bit) -> i64: a >2^63-byte file would overflow. Surface a
     // clean error instead of trapping (Debug/ReleaseSafe) or UB (ReleaseFast).
     return std.math.cast(i64, st.size) orelse return error.Overflow;
@@ -301,7 +308,7 @@ pub fn evalExpr(ctx: Ctx, e: *const Expr, env: *Env, depth: u32) Error!Value {
         },
         .method => |m| {
             const kind = method.lookup(m.name) orelse return failExpr(e, error.UnknownMethod);
-            if (m.args.len != method.arity(kind)) return failExpr(e, error.InvalidMethodArity);
+            if (!method.arityOk(kind, m.args.len)) return failExpr(e, error.InvalidMethodArity);
 
             switch (kind) {
                 .formatter => |f| {
@@ -335,7 +342,13 @@ pub fn evalExpr(ctx: Ctx, e: *const Expr, env: *Env, depth: u32) Error!Value {
                 .dir_tree => {
                     const recv = try evalExpr(ctx, m.recv, env, depth);
                     if (recv != .dir) return failExpr(e, error.InvalidMethodReceiver);
-                    return .{ .dir = .{ .path = recv.dir.path, .recursive = true } };
+                    const max_depth: ?u32 = if (m.args.len == 0) null else blk: {
+                        const arg_v = try evalExpr(ctx, m.args[0], env, depth);
+                        if (arg_v != .int) return failExpr(e, error.TypeMismatch);
+                        if (arg_v.int < 0) return failExpr(e, error.InvalidTreeDepth);
+                        break :blk std.math.cast(u32, arg_v.int) orelse return failExpr(e, error.Overflow);
+                    };
+                    return .{ .dir = .{ .path = recv.dir.path, .max_depth = max_depth } };
                 },
             }
         },
@@ -450,14 +463,14 @@ fn openAs(ctx: Ctx, kind: plan.SourceKind, path_or_payload: []const u8) Error!Va
         .hash => return .{ .hash = path_or_payload },
         .file => {
             // §3.3: regular file only — openFile succeeds on directories on Linux.
-            var f = std.Io.Dir.cwd().openFile(ctx.io, path_or_payload, .{}) catch return error.IoFailure;
+            var f = std.Io.Dir.cwd().openFile(ctx.io, path_or_payload, .{}) catch return ioFail(path_or_payload);
             defer f.close(ctx.io);
-            const st = f.stat(ctx.io) catch return error.IoFailure;
-            if (st.kind != .file) return error.IoFailure;
+            const st = f.stat(ctx.io) catch return ioFail(path_or_payload);
+            if (st.kind != .file) return ioFail(path_or_payload);
             return .{ .file = .{ .path = path_or_payload } };
         },
         .dir => {
-            var d = std.Io.Dir.cwd().openDir(ctx.io, path_or_payload, .{}) catch return error.IoFailure;
+            var d = std.Io.Dir.cwd().openDir(ctx.io, path_or_payload, .{}) catch return ioFail(path_or_payload);
             d.close(ctx.io);
             return .{ .dir = .{ .path = path_or_payload } };
         },
@@ -465,7 +478,7 @@ fn openAs(ctx: Ctx, kind: plan.SourceKind, path_or_payload: []const u8) Error!Va
 }
 
 fn listFilesInDir(ctx: Ctx, dir: value.DirVal) Error![]Value {
-    var root = std.Io.Dir.cwd().openDir(ctx.io, dir.path, .{ .iterate = true }) catch return error.IoFailure;
+    var root = std.Io.Dir.cwd().openDir(ctx.io, dir.path, .{ .iterate = true }) catch return ioFail(dir.path);
     defer root.close(ctx.io);
 
     var list: std.ArrayListUnmanaged(Value) = .empty;
@@ -474,30 +487,35 @@ fn listFilesInDir(ctx: Ctx, dir: value.DirVal) Error![]Value {
     var names: std.ArrayListUnmanaged([]const u8) = .empty;
     defer names.deinit(ctx.allocator);
 
-    if (dir.recursive) {
+    if (dir.max_depth == 0) {
+        var it = root.iterate();
+        while (true) {
+            const maybe = it.next(ctx.io) catch return ioFail(dir.path);
+            const entry = maybe orelse break;
+            // Skip symlinks and non-files (directories, etc.).
+            if (entry.kind != .file) continue;
+            const full = try std.fs.path.join(ctx.allocator, &.{ dir.path, entry.name });
+            try names.append(ctx.allocator, full);
+        }
+    } else {
         // Selective walker: enter() failures skip that subtree; siblings stay reachable.
+        // Zig Entry.depth(): 1 = direct child of root. Enter dir iff unlimited or depth <= n.
         var walker = root.walkSelectively(ctx.allocator) catch return error.OutOfMemory;
         defer walker.deinit();
         while (true) {
-            const maybe = walker.next(ctx.io) catch return error.IoFailure;
+            const maybe = walker.next(ctx.io) catch return ioFail(dir.path);
             const entry = maybe orelse break;
             if (entry.kind == .directory) {
-                walker.enter(ctx.io, entry) catch continue;
+                const unlimited = dir.max_depth == null;
+                const within = if (dir.max_depth) |n| entry.depth() <= n else false;
+                if (unlimited or within) {
+                    walker.enter(ctx.io, entry) catch continue;
+                }
                 continue;
             }
             // Skip symlinks and non-files (same policy as flat listing).
             if (entry.kind != .file) continue;
             const full = try std.fs.path.join(ctx.allocator, &.{ dir.path, entry.path });
-            try names.append(ctx.allocator, full);
-        }
-    } else {
-        var it = root.iterate();
-        while (true) {
-            const maybe = it.next(ctx.io) catch return error.IoFailure;
-            const entry = maybe orelse break;
-            // Skip symlinks and non-files (directories, etc.).
-            if (entry.kind != .file) continue;
-            const full = try std.fs.path.join(ctx.allocator, &.{ dir.path, entry.name });
             try names.append(ctx.allocator, full);
         }
     }
@@ -903,6 +921,26 @@ test "negative file window bind is InvalidWindow" {
     var pred: Expr = .{ .kind = .{ .binary = .{ .op = .eq, .left = &offset_p, .right = &neg } } };
 
     try std.testing.expectError(error.InvalidWindow, evalExpr(ctx, &pred, &env, 0));
+}
+
+test "negative tree depth is InvalidTreeDepth" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    var buf: [64]u8 = undefined;
+    var writer: std.Io.Writer = .fixed(&buf);
+    const ctx = testCtx(a, &writer);
+
+    var env: Env = .{};
+    defer env.deinit(a);
+    try env.put(a, "d", .{ .dir = .{ .path = "/tmp" } });
+
+    var name_d: Expr = .{ .kind = .{ .name = "d" } };
+    var neg: Expr = .{ .kind = .{ .int_lit = -1 } };
+    var args = [_]*Expr{&neg};
+    var call: Expr = .{ .kind = .{ .method = .{ .recv = &name_d, .name = "tree", .args = &args } } };
+
+    try std.testing.expectError(error.InvalidTreeDepth, evalExpr(ctx, &call, &env, 0));
 }
 
 test "from string where size select md5" {

--- a/src/l2h/method.zig
+++ b/src/l2h/method.zig
@@ -36,8 +36,14 @@ pub const Kind = union(enum) {
     formatter: Formatter,
     /// Algorithm name is the call's method name (`m.name`); arity 1, result `Bool`.
     hash_check,
-    /// `Dir.tree()` — same path, recursive enumeration flag set (§4.6).
+    /// `Dir.tree()` / `Dir.tree(n)` — same path, depth limit on the Dir (§4.6).
     dir_tree,
+};
+
+/// Allowed argument count range for a method kind.
+pub const Arity = struct {
+    min: usize,
+    max: usize,
 };
 
 pub const ResultKind = enum { string, bool, dir };
@@ -61,11 +67,17 @@ fn lookupFormatter(name: []const u8) ?Formatter {
     return null;
 }
 
-pub fn arity(k: Kind) usize {
+pub fn arityRange(k: Kind) Arity {
     return switch (k) {
-        .formatter, .dir_tree => 0,
-        .hash_check => 1,
+        .formatter => .{ .min = 0, .max = 0 },
+        .hash_check => .{ .min = 1, .max = 1 },
+        .dir_tree => .{ .min = 0, .max = 1 },
     };
+}
+
+pub fn arityOk(k: Kind, n: usize) bool {
+    const r = arityRange(k);
+    return n >= r.min and n <= r.max;
 }
 
 pub fn resultKind(k: Kind) ResultKind {
@@ -237,9 +249,13 @@ test "lookup kind covers formatters, dir_tree, and hash-check" {
     try std.testing.expectEqual(@as(?Kind, .hash_check), lookup("sha1"));
     try std.testing.expect(lookup("nope") == null);
 
-    try std.testing.expectEqual(@as(usize, 0), arity(.{ .formatter = .sfv }));
-    try std.testing.expectEqual(@as(usize, 0), arity(.dir_tree));
-    try std.testing.expectEqual(@as(usize, 1), arity(.hash_check));
+    try std.testing.expectEqual(Arity{ .min = 0, .max = 0 }, arityRange(.{ .formatter = .sfv }));
+    try std.testing.expectEqual(Arity{ .min = 0, .max = 1 }, arityRange(.dir_tree));
+    try std.testing.expectEqual(Arity{ .min = 1, .max = 1 }, arityRange(.hash_check));
+    try std.testing.expect(arityOk(.dir_tree, 0));
+    try std.testing.expect(arityOk(.dir_tree, 1));
+    try std.testing.expect(!arityOk(.dir_tree, 2));
+    try std.testing.expect(!arityOk(.hash_check, 0));
     try std.testing.expectEqual(ResultKind.string, resultKind(.{ .formatter = .json }));
     try std.testing.expectEqual(ResultKind.bool, resultKind(.hash_check));
     try std.testing.expectEqual(ResultKind.dir, resultKind(.dir_tree));

--- a/src/l2h/method.zig
+++ b/src/l2h/method.zig
@@ -3,7 +3,7 @@ const hashes = @import("hashes");
 const value = @import("value.zig");
 
 /// Method catalog for `recv.method(args…)` — Record formatters (§4.7),
-/// hash-check on File/String (§4.8), and Dir recursion (§4.6).
+/// hash-check on File/String (§4.8), and Dir walk helpers (§4.6).
 /// Analogous to `props.zig` for properties.
 /// Receiver may be an identifier or a record literal `{…}`.
 /// Same four-space separator as `hc` SFV / checksum output.
@@ -38,6 +38,8 @@ pub const Kind = union(enum) {
     hash_check,
     /// `Dir.tree()` / `Dir.tree(n)` — same path, depth limit on the Dir (§4.6).
     dir_tree,
+    /// `Dir.skipErrors()` — skip unreadable subdirectories while walking (§4.6).
+    dir_skip_errors,
 };
 
 /// Allowed argument count range for a method kind.
@@ -52,6 +54,7 @@ pub const ResultKind = enum { string, bool, dir };
 pub fn lookup(name: []const u8) ?Kind {
     if (lookupFormatter(name)) |f| return .{ .formatter = f };
     if (std.mem.eql(u8, name, "tree")) return .dir_tree;
+    if (std.mem.eql(u8, name, "skipErrors")) return .dir_skip_errors;
     if (hashes.getHash(name) != null) return .hash_check;
     return null;
 }
@@ -72,6 +75,7 @@ pub fn arityRange(k: Kind) Arity {
         .formatter => .{ .min = 0, .max = 0 },
         .hash_check => .{ .min = 1, .max = 1 },
         .dir_tree => .{ .min = 0, .max = 1 },
+        .dir_skip_errors => .{ .min = 0, .max = 0 },
     };
 }
 
@@ -84,7 +88,7 @@ pub fn resultKind(k: Kind) ResultKind {
     return switch (k) {
         .formatter => .string,
         .hash_check => .bool,
-        .dir_tree => .dir,
+        .dir_tree, .dir_skip_errors => .dir,
     };
 }
 
@@ -245,12 +249,14 @@ test "lookup kind covers formatters, dir_tree, and hash-check" {
     try std.testing.expectEqual(Kind{ .formatter = .json_pretty }, lookup("jsonPretty").?);
     try std.testing.expect(lookup("Sfv") == null);
     try std.testing.expectEqual(@as(?Kind, .dir_tree), lookup("tree"));
+    try std.testing.expectEqual(@as(?Kind, .dir_skip_errors), lookup("skipErrors"));
     try std.testing.expectEqual(@as(?Kind, .hash_check), lookup("md5"));
     try std.testing.expectEqual(@as(?Kind, .hash_check), lookup("sha1"));
     try std.testing.expect(lookup("nope") == null);
 
     try std.testing.expectEqual(Arity{ .min = 0, .max = 0 }, arityRange(.{ .formatter = .sfv }));
     try std.testing.expectEqual(Arity{ .min = 0, .max = 1 }, arityRange(.dir_tree));
+    try std.testing.expectEqual(Arity{ .min = 0, .max = 0 }, arityRange(.dir_skip_errors));
     try std.testing.expectEqual(Arity{ .min = 1, .max = 1 }, arityRange(.hash_check));
     try std.testing.expect(arityOk(.dir_tree, 0));
     try std.testing.expect(arityOk(.dir_tree, 1));
@@ -259,6 +265,7 @@ test "lookup kind covers formatters, dir_tree, and hash-check" {
     try std.testing.expectEqual(ResultKind.string, resultKind(.{ .formatter = .json }));
     try std.testing.expectEqual(ResultKind.bool, resultKind(.hash_check));
     try std.testing.expectEqual(ResultKind.dir, resultKind(.dir_tree));
+    try std.testing.expectEqual(ResultKind.dir, resultKind(.dir_skip_errors));
 }
 
 test "sfv emits name then digest regardless of field order" {

--- a/src/l2h/props.zig
+++ b/src/l2h/props.zig
@@ -14,16 +14,19 @@ pub const Access = enum {
     offset,
     /// File hash window length (semantics §4.5).
     limit,
+    /// Whether the file can be opened and stated as a regular file (§4.3).
+    readable,
     /// `prop` is a known hash algorithm name.
     hash_algo,
 };
 
-pub const ResultKind = enum { string, int };
+pub const ResultKind = enum { string, int, bool };
 
 pub fn resultKind(access: Access) ResultKind {
     return switch (access) {
         .path, .name, .hash_algo => .string,
         .size, .offset, .limit => .int,
+        .readable => .bool,
     };
 }
 
@@ -47,6 +50,7 @@ pub fn lookup(recv: plan.SourceKind, prop: []const u8) ?Access {
             if (std.mem.eql(u8, prop, "size")) return .size;
             if (std.mem.eql(u8, prop, "offset")) return .offset;
             if (std.mem.eql(u8, prop, "limit")) return .limit;
+            if (std.mem.eql(u8, prop, "readable")) return .readable;
             if (hashes.getHash(prop) != null) return .hash_algo;
             return null;
         },
@@ -73,6 +77,7 @@ test "lookup matches semantics catalog for range kinds" {
     try std.testing.expectEqual(@as(?Access, .size), lookup(.file, "size"));
     try std.testing.expectEqual(@as(?Access, .offset), lookup(.file, "offset"));
     try std.testing.expectEqual(@as(?Access, .limit), lookup(.file, "limit"));
+    try std.testing.expectEqual(@as(?Access, .readable), lookup(.file, "readable"));
     try std.testing.expectEqual(@as(?Access, .hash_algo), lookup(.file, "md5"));
     try std.testing.expect(lookup(.file, "nope") == null);
 
@@ -82,6 +87,7 @@ test "lookup matches semantics catalog for range kinds" {
     try std.testing.expect(lookup(.string, "name") == null);
     try std.testing.expect(lookup(.string, "limit") == null);
     try std.testing.expect(lookup(.string, "offset") == null);
+    try std.testing.expect(lookup(.string, "readable") == null);
 
     try std.testing.expectEqual(@as(?Access, .hash_algo), lookup(.hash, "md5"));
     try std.testing.expect(lookup(.hash, "size") == null);
@@ -96,6 +102,7 @@ test "lookup matches semantics catalog for range kinds" {
     try std.testing.expectEqual(ResultKind.int, resultKind(.size));
     try std.testing.expectEqual(ResultKind.int, resultKind(.offset));
     try std.testing.expectEqual(ResultKind.int, resultKind(.limit));
+    try std.testing.expectEqual(ResultKind.bool, resultKind(.readable));
     try std.testing.expectEqual(ResultKind.string, resultKind(.hash_algo));
 }
 

--- a/src/l2h/value.zig
+++ b/src/l2h/value.zig
@@ -22,12 +22,13 @@ pub const FileVal = struct {
     offset: i64 = 0,
 };
 
-/// Directory binding with optional recursive enumeration (§3.4 / §4.6).
+/// Directory binding with optional depth-limited enumeration (§3.4 / §4.6).
 pub const DirVal = struct {
     path: []const u8,
-    /// When true, `from file f in d` walks the whole tree (regular files only).
-    /// Set by `d.tree()`, which returns a new Dir with this flag.
-    recursive: bool = false,
+    /// Max relative directory depth for `from file f in d` (regular files only).
+    /// `0` = flat (default); `n` = descend at most `n` levels; `null` = unlimited.
+    /// Set by `d.tree()` / `d.tree(n)`, which return a new Dir with this field.
+    max_depth: ?u32 = 0,
 };
 
 pub const Value = union(enum) {

--- a/src/l2h/value.zig
+++ b/src/l2h/value.zig
@@ -29,6 +29,9 @@ pub const DirVal = struct {
     /// `0` = flat (default); `n` = descend at most `n` levels; `null` = unlimited.
     /// Set by `d.tree()` / `d.tree(n)`, which return a new Dir with this field.
     max_depth: ?u32 = 0,
+    /// When true, unreadable subdirectories are skipped during walk (§4.6).
+    /// Set by `d.skipErrors()`.
+    skip_errors: bool = false,
 };
 
 pub const Value = union(enum) {


### PR DESCRIPTION
Opt into skipping unreadable subdirs during walks, filter files with where f.readable, and allow method chaining like d.tree().skipErrors().