### PR TITLE
ci: run Linux aarch64 builds on ARM64 runners with native tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,11 @@ jobs:
             os: linux
             arch: x86_64
             runs_on: [self-hosted, linux, x64]
+          - target: aarch64-linux-gnu
+            abi: gnu
+            os: linux
+            arch: aarch64
+            runs_on: [self-hosted, linux, ARM64]
           - target: aarch64-linux-musl
             abi: musl
             os: linux
@@ -239,11 +244,12 @@ jobs:
           path: test-results/
           if-no-files-found: ignore
       - name: Publish pytest results
-        # gnu on x64; musl on ARM64 (only Linux aarch64 matrix leg).
-        if: ${{ !cancelled() && matrix.os == 'linux' && ((matrix.abi == 'gnu' && matrix.arch == 'x86_64') || matrix.arch == 'aarch64') && hashFiles('test-results/**/*.xml') != '' }}
+        # Native Linux gnu only (CUDA path on x64 and ARM64); musl still runs
+        # pytest in linux_build.sh but is not published to avoid duplicate checks.
+        if: ${{ !cancelled() && matrix.abi == 'gnu' && matrix.os == 'linux' && hashFiles('test-results/**/*.xml') != '' }}
         uses: dorny/test-reporter@v3
         with:
-          name: pytest Tests (Linux ${{ matrix.abi }} ${{ matrix.arch }})
+          name: pytest Tests (Linux gnu ${{ matrix.arch }})
           path: test-results/**/*.xml
           reporter: java-junit
           fail-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,8 @@ jobs:
   linux_build:
     name: Linux Build
     needs: [ prepare ]
-    runs-on: [self-hosted, linux, x64]
+    # x86_64 (+ macOS cross) on the x64 runner; native aarch64 Linux on ARM64.
+    runs-on: ${{ matrix.runs_on }}
     permissions:
       contents: read
       checks: write
@@ -171,22 +172,27 @@ jobs:
             abi: gnu
             os: linux
             arch: x86_64
+            runs_on: [self-hosted, linux, x64]
           - target: x86_64-linux-musl
             abi: musl
             os: linux
             arch: x86_64
+            runs_on: [self-hosted, linux, x64]
           - target: aarch64-linux-musl
             abi: musl
             os: linux
             arch: aarch64
+            runs_on: [self-hosted, linux, ARM64]
           - target: aarch64-macos-none
             abi: none
             os: macos
             arch: aarch64
+            runs_on: [self-hosted, linux, x64]
           - target: x86_64-macos-none
             abi: none
             os: macos
             arch: x86_64
+            runs_on: [self-hosted, linux, x64]
 
     steps:
       - uses: actions/checkout@v7
@@ -226,17 +232,18 @@ jobs:
           PROJECT_BASE_PATH: "${{runner.workspace}}/${{ env.PROJECT_NAME }}"
 
       - name: Upload test results
-        if: ${{ !cancelled() && matrix.os == 'linux' && matrix.arch == 'x86_64' }}
+        if: ${{ !cancelled() && matrix.os == 'linux' }}
         uses: actions/upload-artifact@v7
         with:
-          name: test-results-linux-${{ matrix.abi }}
+          name: test-results-linux-${{ matrix.abi }}-${{ matrix.arch }}
           path: test-results/
           if-no-files-found: ignore
       - name: Publish pytest results
-        if: ${{ !cancelled() && matrix.abi == 'gnu' && matrix.os == 'linux' && matrix.arch == 'x86_64' && hashFiles('test-results/**/*.xml') != '' }}
+        # gnu on x64; musl on ARM64 (only Linux aarch64 matrix leg).
+        if: ${{ !cancelled() && matrix.os == 'linux' && ((matrix.abi == 'gnu' && matrix.arch == 'x86_64') || matrix.arch == 'aarch64') && hashFiles('test-results/**/*.xml') != '' }}
         uses: dorny/test-reporter@v3
         with:
-          name: pytest Tests (Linux gnu)
+          name: pytest Tests (Linux ${{ matrix.abi }} ${{ matrix.arch }})
           path: test-results/**/*.xml
           reporter: java-junit
           fail-on-error: true

--- a/build.zig
+++ b/build.zig
@@ -349,6 +349,7 @@ fn resolveTarget(b: *std.Build) std.Build.ResolvedTarget {
     // crc32.c's HW CRC32C path. Only replace the portable baseline default —
     // honor `-Dcpu=…` (e.g. Windows core2 portable builds).
     // aarch64-macos defaults to apple_m1 (Apple Silicon baseline for M1+).
+    // aarch64-linux baseline adds +crc (near-universal ARMv8 CRC for crc32c).
     const arch = query.cpu_arch orelse builtin.cpu.arch;
     const os = query.os_tag orelse builtin.target.os.tag;
     if (arch == .x86_64) {
@@ -362,6 +363,13 @@ fn resolveTarget(b: *std.Build) std.Build.ResolvedTarget {
         switch (query.cpu_model) {
             .baseline, .determined_by_arch_os => {
                 query.cpu_model = .{ .explicit = &std.Target.aarch64.cpu.apple_m1 };
+            },
+            .native, .explicit => {},
+        }
+    } else if (arch == .aarch64 and os == .linux) {
+        switch (query.cpu_model) {
+            .baseline, .determined_by_arch_os => {
+                query.cpu_features_add = std.Target.aarch64.featureSet(&.{.crc});
             },
             .native, .explicit => {},
         }

--- a/build.zig
+++ b/build.zig
@@ -172,6 +172,7 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("src/hc/modes.zig"),
         .target = target,
         .optimize = optimize,
+        .strip = strip,
         .link_libc = true,
     });
     modes_mod.linkLibrary(crypto_lib);
@@ -217,6 +218,7 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("src/tests/hash_test.zig"),
         .target = target,
         .optimize = optimize,
+        .strip = strip,
         .link_libc = true,
     });
     hash_gtest_mod.linkLibrary(crypto_lib);
@@ -235,6 +237,7 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("src/tests/brute_force_test.zig"),
         .target = target,
         .optimize = optimize,
+        .strip = strip,
         .link_libc = true,
     });
     bf_gtest_mod.linkLibrary(crypto_lib);

--- a/linux_build.sh
+++ b/linux_build.sh
@@ -25,10 +25,11 @@ OUT_DIR="zig-out"
 BIN_DIR="bin"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "${SCRIPT_DIR}"
-# pytest runner resolves hc via PROJECT_BASE_PATH/build-x86_64-linux-${ABI}-Release/hc
+# pytest runner resolves hc via PROJECT_BASE_PATH/build-${ARCH}-linux-${ABI}-Release/hc
 # when set; default to the repo root so local runs match CI.
 export PROJECT_BASE_PATH="${PROJECT_BASE_PATH:-${SCRIPT_DIR}}"
 export HC_TEST_ABI="${HC_TEST_ABI:-${ABI}}"
+export HC_TEST_ARCH="${HC_TEST_ARCH:-${ARCH}}"
 
 mkdir -p "${BIN_DIR}"
 TEST_RESULTS_DIR="${SCRIPT_DIR}/test-results"
@@ -95,10 +96,11 @@ cp -v "${OUT_DIR}/bin/hc" "${BIN_DIR}/hc"
 cp -v "${OUT_DIR}/bin/l2h" "${BIN_DIR}/l2h" 2>/dev/null || true
 cp -v LICENSE.txt "${BIN_DIR}/LICENSE.txt" 2>/dev/null || true
 
-# 4. Unit tests. Musl test binaries are static and run on the gnu host.
-#    `test` already pulls in l2h; `test-l2h` is run explicitly for a clear
-#    failure surface (same as windows_build.ps1). Logs + Job Summary in CI.
-if [[ "${ARCH}" = "x86_64" ]] && [[ "${OS}" = "linux" ]]; then
+# 4. Unit tests — native Linux only (x86_64 or aarch64 host). Musl test
+#    binaries are static and run on the gnu host. `test` already pulls in l2h;
+#    `test-l2h` is run explicitly for a clear failure surface (same as
+#    windows_build.ps1). Logs + Job Summary in CI.
+if [[ "${OS}" = "linux" ]] && [[ "${ARCH}" = "${HOST_ARCH}" ]]; then
   zig_test_args=(test "-Dtarget=${TRIPLE}")
   zig_l2h_args=(test-l2h "-Dtarget=${TRIPLE}")
   if [[ -n "${CUDA_FLAG}" ]]; then
@@ -110,11 +112,11 @@ if [[ "${ARCH}" = "x86_64" ]] && [[ "${OS}" = "linux" ]]; then
 fi
 
 # 5. pytest black-box regression. runner.py looks for
-#    ${PROJECT_BASE_PATH}/build-x86_64-linux-${ABI}-Release/hc — point that at the
-#    zig-built binary. x86_64/linux only (musl artefact is runnable on the gnu host).
-#    JUnit XML lands in test-results/ for dorny/test-reporter in CI.
-if [[ "${ARCH}" = "x86_64" ]] && [[ "${OS}" = "linux" ]]; then
-  COMPAT_DIR="build-x86_64-linux-${ABI}-${BUILD_CONF}"
+#    ${PROJECT_BASE_PATH}/build-${ARCH}-linux-${ABI}-Release/hc — point that at
+#    the zig-built binary. Native Linux only (musl artefact is runnable on the
+#    gnu host). JUnit XML lands in test-results/ for dorny/test-reporter in CI.
+if [[ "${OS}" = "linux" ]] && [[ "${ARCH}" = "${HOST_ARCH}" ]]; then
+  COMPAT_DIR="build-${ARCH}-linux-${ABI}-${BUILD_CONF}"
   mkdir -p "${COMPAT_DIR}"
   ln -sfn "${SCRIPT_DIR}/${OUT_DIR}/bin/hc" "${COMPAT_DIR}/hc"
   ln -sfn "${SCRIPT_DIR}/${OUT_DIR}/bin/l2h" "${COMPAT_DIR}/l2h"
@@ -136,6 +138,7 @@ if [[ "${ARCH}" = "x86_64" ]] && [[ "${OS}" = "linux" ]]; then
   python -m pip install -q -r src/_tst.py/requirements.txt
   export HC_TEST_DIR="${TEST_RESULTS_DIR}/_tst.py-workdir"
   export HC_TEST_ABI="${ABI}"
+  export HC_TEST_ARCH="${ARCH}"
   # Parallel via xdist; file → group "file", crack → group "crack" (GPU VRAM),
   # each group serial on one worker (--dist loadgroup).
   python -m pytest src/_tst.py \

--- a/linux_build.sh
+++ b/linux_build.sh
@@ -4,8 +4,10 @@
 # TGZ artefact with both binaries (hc + l2h + LICENSE).
 #
 # C dependencies the Zig build cannot yet build itself (OpenSSL libcrypto)
-# are provisioned by scripts/build_external_libs.sh on first run and
-# cached afterwards (mirrors the Windows job's c:/external_lib strategy).
+# are provisioned by scripts/build_external_libs.sh into workspace
+# external_lib/. On CI (or when HC_EXTERNAL_LIB_CACHE is set) a persistent
+# agent cache is seeded/written so checkout cleans do not force a full
+# OpenSSL rebuild (Windows: C:\external_lib / HC_EXTERNAL_LIB_CACHE).
 #
 # Usage: ./linux_build.sh [abi] [os] [arch]
 #   abi:  gnu|musl|none (default gnu; use none for macos)

--- a/linux_build.sh
+++ b/linux_build.sh
@@ -103,8 +103,8 @@ cp -v LICENSE.txt "${BIN_DIR}/LICENSE.txt" 2>/dev/null || true
 #    `test-l2h` is run explicitly for a clear failure surface (same as
 #    windows_build.ps1). Logs + Job Summary in CI.
 if [[ "${OS}" = "linux" ]] && [[ "${ARCH}" = "${HOST_ARCH}" ]]; then
-  zig_test_args=(test "-Dtarget=${TRIPLE}")
-  zig_l2h_args=(test-l2h "-Dtarget=${TRIPLE}")
+  zig_test_args=(test "-Dtarget=${TRIPLE}" "-Doptimize=${ZIG_OPTIMIZE}")
+  zig_l2h_args=(test-l2h "-Dtarget=${TRIPLE}" "-Doptimize=${ZIG_OPTIMIZE}")
   if [[ -n "${CUDA_FLAG}" ]]; then
     zig_test_args+=("${CUDA_FLAG}")
     zig_l2h_args+=("${CUDA_FLAG}")

--- a/scripts/build_external_libs.ps1
+++ b/scripts/build_external_libs.ps1
@@ -4,25 +4,27 @@
   Provisions Windows C deps for the Zig build: static OpenSSL libcrypto + headers.
 
 .DESCRIPTION
-  Mirrors scripts/build_external_libs.sh (the Linux provisioner): idempotent
-  download + install when artifacts are missing. Workspace layout stays Windows-
-  specific (external_lib\openssl\..., no lib/ parent).
+  Mirrors scripts/build_external_libs.sh (the Linux provisioner).
 
-  OpenSSL: build.zig links external_lib\openssl\lib\libcrypto.lib for
-  MD5/SHA*/RIPEMD160/WHIRLPOOL (parity with CMake). On miss: optional seed from
-  HC_EXTERNAL_LIB_CACHE / C:\external_lib when libcrypto.lib is present, else
-  download openssl sources, Configure VC-WIN64A (/FS for parallel PDB; native
-  Windows keeps platform asm — no no-asm), jom (or nmake) build, then nmake
-  install_sw (serial: jom install races on recursive depend). Perl is required
-  only on the download path.
+  Workspace install (what build.zig links):
+    external_lib\openssl\...
 
-  Idempotent: skips work when libcrypto.lib is present.
+  Persistent agent cache (CI / HC_EXTERNAL_LIB_CACHE only; local stays in
+  workspace external_lib\openssl with no C:\external_lib write-back):
+    ${HC_EXTERNAL_LIB_CACHE:-C:\external_lib}\openssl-${ver}-${arch}-windows-msvc-asm\
+  Rebuild only when the cached tree is missing or its version stamp differs.
+  After a successful CI build the tree is written back into the cache.
+
+  OpenSSL: Configure VC-WIN64A (/FS for parallel PDB; native Windows keeps
+  platform asm — no no-asm), jom (or nmake) build, then nmake install_sw
+  (serial: jom install races on recursive depend). Perl is required only on
+  the download path.
 
 .PARAMETER Arch
-  Target arch (default x86_64). Reserved for future use.
+  Target arch (default x86_64).
 
 .PARAMETER OpenSslVer
-  OpenSSL source version to fetch (default 4.0.0, matching Linux).
+  OpenSSL source version to fetch (default 4.0.1, matching Linux).
 #>
 [CmdletBinding()]
 param(
@@ -39,116 +41,185 @@ $Root = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
 $LibInstallSrc = Join-Path $Root "external_lib\src"
 $OpenSslPrefix = Join-Path $Root "external_lib\openssl"
 $OpenSslLib = Join-Path $OpenSslPrefix "lib\libcrypto.lib"
-$CacheRoot = if ($env:HC_EXTERNAL_LIB_CACHE) { $env:HC_EXTERNAL_LIB_CACHE } else { "C:\external_lib" }
+$OpenSslVersionStamp = Join-Path $OpenSslPrefix ".hc-openssl-version"
+
+$CacheRoot = $null
+$UseAgentCache = $false
+if ($env:HC_EXTERNAL_LIB_CACHE) {
+    $UseAgentCache = $true
+    $CacheRoot = $env:HC_EXTERNAL_LIB_CACHE
+} elseif ($env:GITHUB_ACTIONS -eq "true" -or $env:CI -eq "true") {
+    $UseAgentCache = $true
+    $CacheRoot = "C:\external_lib"
+}
+
+# Windows builds are always native MSVC + asm for this provisioner.
+$CacheKey = "openssl-$OpenSslVer-$Arch-windows-msvc-asm"
+$CacheDir = if ($UseAgentCache) { Join-Path $CacheRoot $CacheKey } else { $null }
+$CachedLib = if ($UseAgentCache) { Join-Path $CacheDir "lib\libcrypto.lib" } else { $null }
+$CachedVersionStamp = if ($UseAgentCache) { Join-Path $CacheDir ".hc-openssl-version" } else { $null }
+$CacheSrcDir = if ($UseAgentCache) { Join-Path $CacheRoot "src" } else { $null }
+$CacheTarball = if ($UseAgentCache) { Join-Path $CacheSrcDir "openssl-$OpenSslVer.tar.gz" } else { $null }
+
+function Test-OpenSslReady {
+    param([string]$Prefix, [string]$Lib, [string]$Stamp, [string]$Ver)
+    if (-not (Test-Path -LiteralPath $Lib)) { return $false }
+    if (-not (Test-Path -LiteralPath $Stamp)) { return $false }
+    $got = (Get-Content -LiteralPath $Stamp -Raw).Trim()
+    return ($got -eq $Ver)
+}
+
+function Copy-OpenSslTree {
+    param([string]$From, [string]$To)
+    if (Test-Path -LiteralPath $To) {
+        Remove-Item -LiteralPath $To -Recurse -Force
+    }
+    New-Item -ItemType Directory -Force -Path (Split-Path -Parent $To) | Out-Null
+    Copy-Item -Path $From -Destination $To -Recurse -Force
+}
 
 New-Item -ItemType Directory -Force -Path $LibInstallSrc | Out-Null
+if ($UseAgentCache) {
+    New-Item -ItemType Directory -Force -Path $CacheSrcDir | Out-Null
+}
 
-if (Test-Path -LiteralPath $OpenSslLib) {
-    Write-Output "==> external_lib OpenSSL libcrypto present"
+# 1. Workspace already has the right version → done.
+if (Test-OpenSslReady -Prefix $OpenSslPrefix -Lib $OpenSslLib -Stamp $OpenSslVersionStamp -Ver $OpenSslVer) {
+    Write-Output "==> external_lib already provisioned (OpenSSL $OpenSslVer)"
     exit 0
 }
 
-$CachedOpenSsl = Join-Path $CacheRoot "openssl"
-$CachedLib = Join-Path $CachedOpenSsl "lib\libcrypto.lib"
-if (Test-Path -LiteralPath $CachedLib) {
-    Write-Output "==> seeding OpenSSL from $CachedOpenSsl -> $OpenSslPrefix"
-    New-Item -ItemType Directory -Force -Path $OpenSslPrefix | Out-Null
-    Copy-Item -Path (Join-Path $CachedOpenSsl "*") -Destination $OpenSslPrefix -Recurse -Force
+# 2. Persistent cache hit (CI / HC_EXTERNAL_LIB_CACHE) → seed workspace.
+if ($UseAgentCache -and (Test-OpenSslReady -Prefix $CacheDir -Lib $CachedLib -Stamp $CachedVersionStamp -Ver $OpenSslVer)) {
+    Write-Output "==> seeding OpenSSL $OpenSslVer from cache $CacheDir -> $OpenSslPrefix"
+    Copy-OpenSslTree -From $CacheDir -To $OpenSslPrefix
+    if (Test-OpenSslReady -Prefix $OpenSslPrefix -Lib $OpenSslLib -Stamp $OpenSslVersionStamp -Ver $OpenSslVer) {
+        Write-Output "==> external_lib OpenSSL ready ($OpenSslLib)"
+        exit 0
+    }
+    Write-Output "warning: cache seed incomplete; rebuilding"
+}
+
+# Stale workspace tree (wrong/missing version) → clear before rebuild.
+if (Test-Path -LiteralPath $OpenSslPrefix) {
+    Remove-Item -LiteralPath $OpenSslPrefix -Recurse -Force
+}
+
+Write-Output "==> provisioning external_lib OpenSSL (libcrypto) for windows-msvc ($OpenSslVer) (arch=$Arch)"
+if ($UseAgentCache) {
+    Write-Output "    cache: $CacheDir"
 } else {
-    Write-Output "==> provisioning external_lib OpenSSL (libcrypto) for windows-msvc ($OpenSslVer) (arch=$Arch)"
+    Write-Output "    cache: disabled (local workspace-only)"
+}
 
-    $perl = Get-Command perl -ErrorAction SilentlyContinue
-    if (-not $perl) {
-        throw "perl not found on PATH (required to Configure OpenSSL). Install Strawberry Perl, or seed via HC_EXTERNAL_LIB_CACHE / C:\external_lib\openssl (with lib\libcrypto.lib)."
-    }
+$perl = Get-Command perl -ErrorAction SilentlyContinue
+if (-not $perl) {
+    throw "perl not found on PATH (required to Configure OpenSSL). Install Strawberry Perl, or seed via HC_EXTERNAL_LIB_CACHE / C:\external_lib (versioned openssl-* tree with lib\libcrypto.lib)."
+}
 
-    # OpenSSL VC-WIN64A needs the x64 MSVC toolchain (cl/lib/nmake). A plain
-    # shell or an x86 Developer Prompt yields missing nmake or LNK1112.
-    function Import-VcVars64 {
-        $vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
-        if (-not (Test-Path -LiteralPath $vswhere)) { return $false }
-        $vsRoot = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
-        if (-not $vsRoot) { return $false }
-        $vcvars = Join-Path $vsRoot "VC\Auxiliary\Build\vcvars64.bat"
-        if (-not (Test-Path -LiteralPath $vcvars)) { return $false }
-        Write-Output "==> importing MSVC x64 env ($vcvars)"
-        cmd /c "`"$vcvars`" >nul && set" | ForEach-Object {
-            if ($_ -match '^(.*?)=(.*)$') {
-                Set-Item -LiteralPath "Env:$($Matches[1])" -Value $Matches[2]
-            }
-        }
-        return $true
-    }
-
-    $needX64 = (-not (Get-Command nmake -ErrorAction SilentlyContinue)) -or
-        ($env:VSCMD_ARG_TGT_ARCH -and $env:VSCMD_ARG_TGT_ARCH -ne "x64")
-    if ($needX64) {
-        if (-not (Import-VcVars64)) {
-            throw "nmake/x64 MSVC not available. Install VS C++ tools, or run from x64 Native Tools / Launch-VsDevShell.ps1 -Arch amd64."
+# OpenSSL VC-WIN64A needs the x64 MSVC toolchain (cl/lib/nmake). A plain
+# shell or an x86 Developer Prompt yields missing nmake or LNK1112.
+function Import-VcVars64 {
+    $vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
+    if (-not (Test-Path -LiteralPath $vswhere)) { return $false }
+    $vsRoot = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+    if (-not $vsRoot) { return $false }
+    $vcvars = Join-Path $vsRoot "VC\Auxiliary\Build\vcvars64.bat"
+    if (-not (Test-Path -LiteralPath $vcvars)) { return $false }
+    Write-Output "==> importing MSVC x64 env ($vcvars)"
+    cmd /c "`"$vcvars`" >nul && set" | ForEach-Object {
+        if ($_ -match '^(.*?)=(.*)$') {
+            Set-Item -LiteralPath "Env:$($Matches[1])" -Value $Matches[2]
         }
     }
+    return $true
+}
 
-    $nmake = Get-Command nmake -ErrorAction SilentlyContinue
-    if (-not $nmake) {
-        throw "nmake not found on PATH after vcvars64 (run from a VS developer / msvc-dev-cmd environment)."
+$needX64 = (-not (Get-Command nmake -ErrorAction SilentlyContinue)) -or
+    ($env:VSCMD_ARG_TGT_ARCH -and $env:VSCMD_ARG_TGT_ARCH -ne "x64")
+if ($needX64) {
+    if (-not (Import-VcVars64)) {
+        throw "nmake/x64 MSVC not available. Install VS C++ tools, or run from x64 Native Tools / Launch-VsDevShell.ps1 -Arch amd64."
     }
-    if ($env:VSCMD_ARG_TGT_ARCH -and $env:VSCMD_ARG_TGT_ARCH -ne "x64") {
-        throw "VS target arch is still '$($env:VSCMD_ARG_TGT_ARCH)' after vcvars64 (need x64)."
-    }
+}
 
-    $jom = Get-Command jom -ErrorAction SilentlyContinue
-    $makeCmd = if ($jom) { $jom.Source } else { $nmake.Source }
-    $makeName = if ($jom) { "jom" } else { "nmake" }
+$nmake = Get-Command nmake -ErrorAction SilentlyContinue
+if (-not $nmake) {
+    throw "nmake not found on PATH after vcvars64 (run from a VS developer / msvc-dev-cmd environment)."
+}
+if ($env:VSCMD_ARG_TGT_ARCH -and $env:VSCMD_ARG_TGT_ARCH -ne "x64") {
+    throw "VS target arch is still '$($env:VSCMD_ARG_TGT_ARCH)' after vcvars64 (need x64)."
+}
 
-    $OpenSslSrcName = "openssl-$OpenSslVer"
-    $OpenSslSrcDir = Join-Path $LibInstallSrc $OpenSslSrcName
-    $OpenSslTar = Join-Path $LibInstallSrc "$OpenSslSrcName.tar.gz"
-    $OpenSslUrl = "https://github.com/openssl/openssl/releases/download/$OpenSslSrcName/$OpenSslSrcName.tar.gz"
+$jom = Get-Command jom -ErrorAction SilentlyContinue
+$makeCmd = if ($jom) { $jom.Source } else { $nmake.Source }
+$makeName = if ($jom) { "jom" } else { "nmake" }
 
-    if (-not (Test-Path -LiteralPath $OpenSslSrcDir)) {
-        if (-not (Test-Path -LiteralPath $OpenSslTar)) {
-            Write-Output "==> downloading $OpenSslSrcName.tar.gz"
-            Invoke-WebRequest -Uri $OpenSslUrl -OutFile $OpenSslTar -UseBasicParsing
-        }
-        Write-Output "==> extracting $OpenSslTar"
-        & tar -xzf $OpenSslTar -C $LibInstallSrc
-        if ($LASTEXITCODE -ne 0) { throw "OpenSSL extract failed (exit $LASTEXITCODE)" }
-        if (-not (Test-Path -LiteralPath $OpenSslSrcDir)) {
-            throw "OpenSSL extract did not produce $OpenSslSrcDir"
-        }
-    }
+$OpenSslSrcName = "openssl-$OpenSslVer"
+$OpenSslSrcDir = Join-Path $LibInstallSrc $OpenSslSrcName
+$OpenSslTar = Join-Path $LibInstallSrc "$OpenSslSrcName.tar.gz"
+$OpenSslUrl = "https://github.com/openssl/openssl/releases/download/$OpenSslSrcName/$OpenSslSrcName.tar.gz"
 
-    Push-Location $OpenSslSrcDir
-    try {
-        # /FS: parallel cl (jom) may share one /Fd PDB; without it MSVC emits C1041.
-        # Native Windows build — keep AES-NI / SHA asm (do not pass no-asm).
-        & perl Configure VC-WIN64A -static no-apps /FS --prefix=$OpenSslPrefix `
-            "--openssldir=$OpenSslPrefix\ssl"
-        if ($LASTEXITCODE -ne 0) { throw "OpenSSL Configure failed (exit $LASTEXITCODE)" }
-        & perl -I. -Mconfigdata -e "die qq(OpenSSL asm disabled on native Windows build; digests need platform asm`n) if `$disabled{asm}; die qq(OpenSSL Configure left asm_arch empty`n) unless `$target{asm_arch}; print qq(OpenSSL asm enabled (asm_arch=`$target{asm_arch})`n)"
-        if ($LASTEXITCODE -ne 0) { throw "OpenSSL asm check failed (exit $LASTEXITCODE)" }
-        if ($jom) {
-            Write-Output "==> building OpenSSL with jom -j$env:NUMBER_OF_PROCESSORS"
-            & $makeCmd "-j$env:NUMBER_OF_PROCESSORS"
-        } else {
-            Write-Output "==> building OpenSSL with nmake"
-            & $makeCmd
-        }
-        if ($LASTEXITCODE -ne 0) { throw "OpenSSL $makeName failed (exit $LASTEXITCODE)" }
-        # install_sw must be serial: parallel jom re-enters `depend` and fails
-        # with Error 13 / build_inst_programs Error 2 on this runner.
-        Write-Output "==> installing OpenSSL with nmake install_sw"
-        & $nmake.Source install_sw
-        if ($LASTEXITCODE -ne 0) { throw "OpenSSL nmake install_sw failed (exit $LASTEXITCODE)" }
+if ($UseAgentCache) {
+    if (-not (Test-Path -LiteralPath $CacheTarball)) {
+        Write-Output "==> downloading $OpenSslSrcName.tar.gz"
+        Invoke-WebRequest -Uri $OpenSslUrl -OutFile $CacheTarball -UseBasicParsing
     }
-    finally {
-        Pop-Location
+    Copy-Item -LiteralPath $CacheTarball -Destination $OpenSslTar -Force
+} elseif (-not (Test-Path -LiteralPath $OpenSslTar)) {
+    Write-Output "==> downloading $OpenSslSrcName.tar.gz"
+    Invoke-WebRequest -Uri $OpenSslUrl -OutFile $OpenSslTar -UseBasicParsing
+}
+
+if (Test-Path -LiteralPath $OpenSslSrcDir) {
+    Remove-Item -LiteralPath $OpenSslSrcDir -Recurse -Force
+}
+Write-Output "==> extracting $OpenSslTar"
+& tar -xzf $OpenSslTar -C $LibInstallSrc
+if ($LASTEXITCODE -ne 0) { throw "OpenSSL extract failed (exit $LASTEXITCODE)" }
+if (-not (Test-Path -LiteralPath $OpenSslSrcDir)) {
+    throw "OpenSSL extract did not produce $OpenSslSrcDir"
+}
+
+Push-Location $OpenSslSrcDir
+try {
+    # /FS: parallel cl (jom) may share one /Fd PDB; without it MSVC emits C1041.
+    # Native Windows build — keep AES-NI / SHA asm (do not pass no-asm).
+    & perl Configure VC-WIN64A -static no-apps /FS --prefix=$OpenSslPrefix `
+        "--openssldir=$OpenSslPrefix\ssl"
+    if ($LASTEXITCODE -ne 0) { throw "OpenSSL Configure failed (exit $LASTEXITCODE)" }
+    & perl -I. -Mconfigdata -e "die qq(OpenSSL asm disabled on native Windows build; digests need platform asm`n) if `$disabled{asm}; die qq(OpenSSL Configure left asm_arch empty`n) unless `$target{asm_arch}; print qq(OpenSSL asm enabled (asm_arch=`$target{asm_arch})`n)"
+    if ($LASTEXITCODE -ne 0) { throw "OpenSSL asm check failed (exit $LASTEXITCODE)" }
+    if ($jom) {
+        Write-Output "==> building OpenSSL with jom -j$env:NUMBER_OF_PROCESSORS"
+        & $makeCmd "-j$env:NUMBER_OF_PROCESSORS"
+    } else {
+        Write-Output "==> building OpenSSL with nmake"
+        & $makeCmd
     }
+    if ($LASTEXITCODE -ne 0) { throw "OpenSSL $makeName failed (exit $LASTEXITCODE)" }
+    # install_sw must be serial: parallel jom re-enters `depend` and fails
+    # with Error 13 / build_inst_programs Error 2 on this runner.
+    Write-Output "==> installing OpenSSL with nmake install_sw"
+    & $nmake.Source install_sw
+    if ($LASTEXITCODE -ne 0) { throw "OpenSSL nmake install_sw failed (exit $LASTEXITCODE)" }
+}
+finally {
+    Pop-Location
 }
 
 if (-not (Test-Path -LiteralPath $OpenSslLib)) {
     throw "OpenSSL provisioning did not produce $OpenSslLib"
 }
+Set-Content -LiteralPath $OpenSslVersionStamp -Value $OpenSslVer
+
+# Write-back only on CI / when HC_EXTERNAL_LIB_CACHE is set.
+if ($UseAgentCache) {
+    Write-Output "==> caching OpenSSL $OpenSslVer -> $CacheDir"
+    Copy-OpenSslTree -From $OpenSslPrefix -To $CacheDir
+    Set-Content -LiteralPath $CachedVersionStamp -Value $OpenSslVer
+}
+
 Write-Output "==> external_lib OpenSSL ready ($OpenSslLib)"
 # Explicit exit so the caller sees 0: $LASTEXITCODE tracks native exes and can
 # otherwise retain a stale non-zero from earlier CI/shell steps.

--- a/scripts/build_external_libs.ps1
+++ b/scripts/build_external_libs.ps1
@@ -11,9 +11,10 @@
   OpenSSL: build.zig links external_lib\openssl\lib\libcrypto.lib for
   MD5/SHA*/RIPEMD160/WHIRLPOOL (parity with CMake). On miss: optional seed from
   HC_EXTERNAL_LIB_CACHE / C:\external_lib when libcrypto.lib is present, else
-  download openssl sources, Configure VC-WIN64A (/FS for parallel PDB),
-  jom (or nmake) build, then nmake install_sw (serial: jom install races
-  on recursive depend). Perl is required only on the download path.
+  download openssl sources, Configure VC-WIN64A (/FS for parallel PDB; native
+  Windows keeps platform asm — no no-asm), jom (or nmake) build, then nmake
+  install_sw (serial: jom install races on recursive depend). Perl is required
+  only on the download path.
 
   Idempotent: skips work when libcrypto.lib is present.
 
@@ -120,9 +121,12 @@ if (Test-Path -LiteralPath $CachedLib) {
     Push-Location $OpenSslSrcDir
     try {
         # /FS: parallel cl (jom) may share one /Fd PDB; without it MSVC emits C1041.
+        # Native Windows build — keep AES-NI / SHA asm (do not pass no-asm).
         & perl Configure VC-WIN64A -static no-apps /FS --prefix=$OpenSslPrefix `
             "--openssldir=$OpenSslPrefix\ssl"
         if ($LASTEXITCODE -ne 0) { throw "OpenSSL Configure failed (exit $LASTEXITCODE)" }
+        & perl -I. -Mconfigdata -e "die qq(OpenSSL asm disabled on native Windows build; digests need platform asm`n) if `$disabled{asm}; die qq(OpenSSL Configure left asm_arch empty`n) unless `$target{asm_arch}; print qq(OpenSSL asm enabled (asm_arch=`$target{asm_arch})`n)"
+        if ($LASTEXITCODE -ne 0) { throw "OpenSSL asm check failed (exit $LASTEXITCODE)" }
         if ($jom) {
             Write-Output "==> building OpenSSL with jom -j$env:NUMBER_OF_PROCESSORS"
             & $makeCmd "-j$env:NUMBER_OF_PROCESSORS"

--- a/scripts/build_external_libs.sh
+++ b/scripts/build_external_libs.sh
@@ -4,15 +4,14 @@
 # googletest/pcre/expat/argtable3/APR/apr-util are not needed by the Zig port
 # (pcre2 is a Zig package; bf is pool-free).
 #
-# Idempotent: if libcrypto.a already exists for this triple, nothing is rebuilt.
-# Each arch/os/abi combination gets its own install prefix:
+# Workspace install (what build.zig links):
 #   external_lib/lib/openssl-${arch}-${os}-${abi}/
-# Examples:
-#   openssl-x86_64-linux-gnu
-#   openssl-x86_64-linux-musl
-#   openssl-aarch64-linux-gnu
-#   openssl-x86_64-macos-none
-#   openssl-aarch64-macos-none
+#
+# Persistent agent cache (CI / HC_EXTERNAL_LIB_CACHE only; local stays in
+# workspace external_lib/ with no ~/.cache write-back):
+#   ${HC_EXTERNAL_LIB_CACHE:-~/.cache/hc-external-lib}/
+#     openssl-${ver}-${arch}-${os}-${abi}-{asm|noasm}/
+# Rebuild only when the cached tree is missing or its version stamp differs.
 #
 # Built with `zig cc -target ${arch}-${os}-${abi}` and an explicit OpenSSL
 # Configure target so cross builds (Linux→macOS, x86_64→aarch64) produce the
@@ -34,11 +33,13 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 LIB_INSTALL_SRC="${ROOT}/external_lib/src"
 LIB_INSTALL_PREFIX="${ROOT}/external_lib/lib"
 
-OPENSSL_SRC=openssl-4.0.1
+OPENSSL_VER=4.0.1
+OPENSSL_SRC="openssl-${OPENSSL_VER}"
 OPENSSL_PREFIX="${LIB_INSTALL_PREFIX}/openssl-${HOST_TRIPLE}"
 # Force a stable libdir across Linux (default lib64) and Darwin (default lib).
 OPENSSL_LIBDIR="${OPENSSL_PREFIX}/lib"
 OPENSSL_MARKER="${OPENSSL_LIBDIR}/libcrypto.a"
+OPENSSL_VERSION_STAMP="${OPENSSL_PREFIX}/.hc-openssl-version"
 
 # OpenSSL Configure target for the requested arch/OS (not host auto-detect).
 openssl_configure_target() {
@@ -95,6 +96,20 @@ assert_openssl_asm_enabled() {
   )
 }
 
+# Copy a provisioned OpenSSL tree into the workspace (or cache).
+seed_openssl_tree() {
+  local from="$1"
+  local to="$2"
+  rm -rf "${to}"
+  mkdir -p "$(dirname "${to}")"
+  cp -a "${from}" "${to}"
+}
+
+openssl_workspace_ready() {
+  [[ -f "${OPENSSL_MARKER}" ]] && [[ -f "${OPENSSL_VERSION_STAMP}" ]] &&
+    [[ "$(cat "${OPENSSL_VERSION_STAMP}")" = "${OPENSSL_VER}" ]]
+}
+
 OPENSSL_TARGET="$(openssl_configure_target)"
 CFLAGS="$(openssl_cflags)"
 
@@ -102,10 +117,36 @@ CFLAGS="$(openssl_cflags)"
 OPENSSL_ASM_ARGS=()
 if openssl_is_native_build; then
   OPENSSL_NATIVE=1
+  OPENSSL_ASM_TAG=asm
 else
   OPENSSL_NATIVE=0
+  OPENSSL_ASM_TAG=noasm
   OPENSSL_ASM_ARGS+=(no-asm)
 fi
+
+# Persistent agent cache: only when HC_EXTERNAL_LIB_CACHE is set, or under CI
+# (GITHUB_ACTIONS/CI). Local developer builds stay workspace-only under
+# external_lib/ — no write to ~/.cache.
+USE_AGENT_CACHE=0
+CACHE_ROOT=""
+if [[ -n "${HC_EXTERNAL_LIB_CACHE:-}" ]]; then
+  USE_AGENT_CACHE=1
+  CACHE_ROOT="${HC_EXTERNAL_LIB_CACHE}"
+elif [[ "${GITHUB_ACTIONS:-}" = "true" ]] || [[ "${CI:-}" = "true" ]]; then
+  USE_AGENT_CACHE=1
+  if [[ -n "${XDG_CACHE_HOME:-}" ]]; then
+    CACHE_ROOT="${XDG_CACHE_HOME}/hc-external-lib"
+  else
+    CACHE_ROOT="${HOME}/.cache/hc-external-lib"
+  fi
+fi
+
+CACHE_KEY="openssl-${OPENSSL_VER}-${HOST_TRIPLE}-${OPENSSL_ASM_TAG}"
+CACHE_DIR="${CACHE_ROOT}/${CACHE_KEY}"
+CACHE_MARKER="${CACHE_DIR}/lib/libcrypto.a"
+CACHE_VERSION_STAMP="${CACHE_DIR}/.hc-openssl-version"
+CACHE_SRC_DIR="${CACHE_ROOT}/src"
+CACHE_TARBALL="${CACHE_SRC_DIR}/${OPENSSL_SRC}.tar.gz"
 
 CC_FLAGS="zig cc -target ${HOST_TRIPLE}"
 AR_FLAGS="zig ar"
@@ -113,26 +154,62 @@ RANLIB_FLAGS="zig ranlib"
 
 mkdir -p "${LIB_INSTALL_SRC}" "${LIB_INSTALL_PREFIX}"
 
-# Already provisioned? Skip entirely (cache hit).
-if [[ -f "${OPENSSL_MARKER}" ]]; then
-  echo "==> external_lib already provisioned (libcrypto present for ${HOST_TRIPLE})"
+# 1. Workspace already has the right version → done.
+if openssl_workspace_ready; then
+  echo "==> external_lib already provisioned (OpenSSL ${OPENSSL_VER} for ${HOST_TRIPLE})"
   exit 0
 fi
 
+# 2. Persistent cache hit (CI / HC_EXTERNAL_LIB_CACHE) → seed workspace.
+if [[ "${USE_AGENT_CACHE}" -eq 1 ]] &&
+  [[ -f "${CACHE_MARKER}" ]] && [[ -f "${CACHE_VERSION_STAMP}" ]] &&
+  [[ "$(cat "${CACHE_VERSION_STAMP}")" = "${OPENSSL_VER}" ]]; then
+  echo "==> seeding OpenSSL ${OPENSSL_VER} from cache ${CACHE_DIR} -> ${OPENSSL_PREFIX}"
+  seed_openssl_tree "${CACHE_DIR}" "${OPENSSL_PREFIX}"
+  if openssl_workspace_ready; then
+    echo "==> external_lib OpenSSL ready (${OPENSSL_MARKER})"
+    exit 0
+  fi
+  echo "warning: cache seed incomplete; rebuilding" >&2
+fi
+
+# Stale workspace tree (wrong/missing version) → clear before rebuild.
+rm -rf "${OPENSSL_PREFIX}"
+
 echo "==> provisioning external_lib OpenSSL (libcrypto) for ${HOST_TRIPLE}"
+echo "    version: ${OPENSSL_VER}"
 echo "    Configure target: ${OPENSSL_TARGET}"
 echo "    prefix: ${OPENSSL_PREFIX}"
+if [[ "${USE_AGENT_CACHE}" -eq 1 ]]; then
+  echo "    cache: ${CACHE_DIR}"
+else
+  echo "    cache: disabled (local workspace-only)"
+fi
 if [[ "${OPENSSL_NATIVE}" -eq 1 ]]; then
   echo "    asm: enabled (native ${ARCH}-${OS})"
 else
   echo "    asm: disabled via no-asm (cross-compile)"
 fi
 
+# Tarball: prefer agent cache when enabled, else workspace external_lib/src.
+TARBALL_DEST="${LIB_INSTALL_SRC}/${OPENSSL_SRC}.tar.gz"
+if [[ "${USE_AGENT_CACHE}" -eq 1 ]]; then
+  mkdir -p "${CACHE_SRC_DIR}"
+  if [[ ! -f "${CACHE_TARBALL}" ]]; then
+    echo "==> downloading ${OPENSSL_SRC}.tar.gz"
+    wget -q -O "${CACHE_TARBALL}" \
+      "https://github.com/openssl/openssl/releases/download/${OPENSSL_SRC}/${OPENSSL_SRC}.tar.gz"
+  fi
+  cp -f "${CACHE_TARBALL}" "${TARBALL_DEST}"
+elif [[ ! -f "${TARBALL_DEST}" ]]; then
+  echo "==> downloading ${OPENSSL_SRC}.tar.gz"
+  wget -q -O "${TARBALL_DEST}" \
+    "https://github.com/openssl/openssl/releases/download/${OPENSSL_SRC}/${OPENSSL_SRC}.tar.gz"
+fi
+
 rm -rf "${LIB_INSTALL_SRC}/${OPENSSL_SRC}"
-(cd "${LIB_INSTALL_SRC}" && {
-  [[ -f "${OPENSSL_SRC}.tar.gz" ]] || wget -q "https://github.com/openssl/openssl/releases/download/${OPENSSL_SRC}/${OPENSSL_SRC}.tar.gz"
-  tar -xzf "${OPENSSL_SRC}.tar.gz"
-})
+(cd "${LIB_INSTALL_SRC}" && tar -xzf "${OPENSSL_SRC}.tar.gz")
+
 (cd "${LIB_INSTALL_SRC}/${OPENSSL_SRC}" && \
   AR="${AR_FLAGS}" RANLIB="${RANLIB_FLAGS}" CC="${CC_FLAGS}" \
   CFLAGS="${CFLAGS}" CXXFLAGS="${CFLAGS}" \
@@ -147,6 +224,14 @@ rm -rf "${LIB_INSTALL_SRC}/${OPENSSL_SRC}"
 if [[ ! -f "${OPENSSL_MARKER}" ]]; then
   echo "error: OpenSSL install did not produce ${OPENSSL_MARKER}" >&2
   exit 1
+fi
+printf '%s\n' "${OPENSSL_VER}" > "${OPENSSL_VERSION_STAMP}"
+
+# Write-back only on CI / when HC_EXTERNAL_LIB_CACHE is set.
+if [[ "${USE_AGENT_CACHE}" -eq 1 ]]; then
+  echo "==> caching OpenSSL ${OPENSSL_VER} -> ${CACHE_DIR}"
+  seed_openssl_tree "${OPENSSL_PREFIX}" "${CACHE_DIR}"
+  printf '%s\n' "${OPENSSL_VER}" > "${CACHE_VERSION_STAMP}"
 fi
 
 echo "==> external_lib provisioning complete (${OPENSSL_MARKER})"

--- a/scripts/build_external_libs.sh
+++ b/scripts/build_external_libs.sh
@@ -18,6 +18,10 @@
 # Configure target so cross builds (Linux→macOS, x86_64→aarch64) produce the
 # correct object format.
 #
+# Platform asm (AES-NI / ARMv8 Crypto Extensions, …) is enabled only for a
+# native build (target arch+os == host). Cross builds pass `no-asm` so the
+# same script works on both without assembler failures.
+#
 # Usage: ./scripts/build_external_libs.sh [arch] [os] [abi]
 set -euo pipefail
 
@@ -53,7 +57,7 @@ openssl_configure_target() {
 }
 
 # Match CMake/linux_build.sh -march=haswell for x86_64; leave ARM to the
-# toolchain defaults (OpenSSL asm selects its own baseline).
+# toolchain defaults (OpenSSL perlasm selects ARMv8 crypto itself).
 openssl_cflags() {
   case "${ARCH}" in
     x86_64) echo "-Ofast -march=haswell -mtune=haswell" ;;
@@ -61,8 +65,47 @@ openssl_cflags() {
   esac
 }
 
+# True when Configure target matches this machine (arch + OS).
+openssl_is_native_build() {
+  local host_arch host_os
+  host_arch="$(uname -m)"
+  case "${host_arch}" in
+    arm64) host_arch=aarch64 ;;
+  esac
+  case "$(uname -s)" in
+    Linux)  host_os=linux ;;
+    Darwin) host_os=macos ;;
+    *)      host_os="" ;;
+  esac
+  [[ -n "${host_os}" ]] && [[ "${ARCH}" = "${host_arch}" ]] && [[ "${OS}" = "${host_os}" ]]
+}
+
+# After Configure on a native build: refuse a no-asm tree.
+assert_openssl_asm_enabled() {
+  local src_dir="$1"
+  (
+    cd "${src_dir}"
+    perl -I. -Mconfigdata -e '
+      die "OpenSSL asm disabled on native build; digests need platform asm\n"
+        if $disabled{asm};
+      my $arch = $target{asm_arch} // "";
+      die "OpenSSL Configure left asm_arch empty\n" if $arch eq "";
+      print "OpenSSL asm enabled (asm_arch=${arch})\n";
+    '
+  )
+}
+
 OPENSSL_TARGET="$(openssl_configure_target)"
 CFLAGS="$(openssl_cflags)"
+
+# Native → platform asm; cross → portable C (no-asm).
+OPENSSL_ASM_ARGS=()
+if openssl_is_native_build; then
+  OPENSSL_NATIVE=1
+else
+  OPENSSL_NATIVE=0
+  OPENSSL_ASM_ARGS+=(no-asm)
+fi
 
 CC_FLAGS="zig cc -target ${HOST_TRIPLE}"
 AR_FLAGS="zig ar"
@@ -79,6 +122,11 @@ fi
 echo "==> provisioning external_lib OpenSSL (libcrypto) for ${HOST_TRIPLE}"
 echo "    Configure target: ${OPENSSL_TARGET}"
 echo "    prefix: ${OPENSSL_PREFIX}"
+if [[ "${OPENSSL_NATIVE}" -eq 1 ]]; then
+  echo "    asm: enabled (native ${ARCH}-${OS})"
+else
+  echo "    asm: disabled via no-asm (cross-compile)"
+fi
 
 rm -rf "${LIB_INSTALL_SRC}/${OPENSSL_SRC}"
 (cd "${LIB_INSTALL_SRC}" && {
@@ -89,7 +137,11 @@ rm -rf "${LIB_INSTALL_SRC}/${OPENSSL_SRC}"
   AR="${AR_FLAGS}" RANLIB="${RANLIB_FLAGS}" CC="${CC_FLAGS}" \
   CFLAGS="${CFLAGS}" CXXFLAGS="${CFLAGS}" \
   ./Configure "${OPENSSL_TARGET}" -static no-apps \
+    "${OPENSSL_ASM_ARGS[@]}" \
     --prefix="${OPENSSL_PREFIX}" --libdir=lib && \
+  if [[ "${OPENSSL_NATIVE}" -eq 1 ]]; then
+    assert_openssl_asm_enabled "${LIB_INSTALL_SRC}/${OPENSSL_SRC}"
+  fi && \
   make -j"$(nproc)" && make install_sw)
 
 if [[ ! -f "${OPENSSL_MARKER}" ]]; then

--- a/src/_tst.py/runner.py
+++ b/src/_tst.py/runner.py
@@ -30,9 +30,10 @@ def resolve_hc_path() -> Path:
     if os.name == "nt":
         candidate = base / "x64" / configuration / "hc.exe"
     elif os.environ.get("PROJECT_BASE_PATH"):
-        # linux_build.sh links zig-out into build-x86_64-linux-${ABI}-Release/hc
+        # linux_build.sh links zig-out into build-${ARCH}-linux-${ABI}-Release/hc
         abi = os.environ.get("HC_TEST_ABI", "gnu")
-        candidate = base / f"build-x86_64-linux-{abi}-{configuration}" / "hc"
+        arch = os.environ.get("HC_TEST_ARCH", "x86_64")
+        candidate = base / f"build-{arch}-linux-{abi}-{configuration}" / "hc"
     else:
         candidate = base / "build" / "hc"
     if candidate.is_file():

--- a/src/hc/hashes.zig
+++ b/src/hc/hashes.zig
@@ -4,10 +4,9 @@ const builtin = @import("builtin");
 const c = @import("c");
 const ltc = @import("ltc"); // libtomcrypt hashes (ripemd256/320) share the hash_state union.
 
-/// CRC32C is offered on x86/x86_64 (SSE4.2 HW, or software on older CPUs
-/// such as core2). Not offered on aarch64/etc.
+/// CRC32C on x86/x86_64 (SSE4.2 HW or software) and aarch64 (CRC32 HW or soft).
 pub const have_crc32c = switch (builtin.cpu.arch) {
-    .x86_64, .x86 => true,
+    .x86_64, .x86, .aarch64 => true,
     else => false,
 };
 

--- a/src/srclib/crc32.c
+++ b/src/srclib/crc32.c
@@ -21,8 +21,13 @@
 #include <nmmintrin.h>
 #endif
 #endif
+#elif defined(__aarch64__) || defined(_M_ARM64)
+#define PREFETCH(location) ((void)0)
+#if HC_CRC32C_HW
+#include <arm_acle.h>
+#endif
 #else
-// Non-x86: no SSE prefetch / CRC32C.
+// Other arches: no SSE prefetch / CRC32C HW intrinsics.
 #define PREFETCH(location) ((void)0)
 #endif
 
@@ -725,8 +730,9 @@ void crc32c_final(crc32_context_t* ctx, uint8_t* hash) {
 }
 
 /**
- * Calculates CRC-32C (Castagnoli). Uses SSE 4.2 `_mm_crc32_*` when the
- * compile target has that ISA; otherwise a software lookup table (core2).
+ * Calculates CRC-32C (Castagnoli). Uses SSE 4.2 `_mm_crc32_*` or ARMv8
+ * `__crc32c*` when the compile target has that ISA; otherwise a software
+ * lookup table (core2 / aarch64 without +crc).
  */
 static uint32_t prcrc32c_calculate(uint32_t crc, const char* buf, size_t len) {
     if (len == 0)
@@ -735,6 +741,7 @@ static uint32_t prcrc32c_calculate(uint32_t crc, const char* buf, size_t len) {
     crc ^= INITIALIZATION_VALUE;
 
 #if HC_CRC32C_HW
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
     for (; (len > 0) && ((size_t)buf & ALIGN_MASK); len--, buf++) {
         crc = _mm_crc32_u8(crc, *buf);
     }
@@ -745,6 +752,25 @@ static uint32_t prcrc32c_calculate(uint32_t crc, const char* buf, size_t len) {
     CALC_CRC(_mm_crc32_u32, crc, uint32_t, buf, len);
     CALC_CRC(_mm_crc32_u16, crc, uint16_t, buf, len);
     CALC_CRC(_mm_crc32_u8, crc, uint8_t, buf, len);
+#elif defined(__aarch64__) || defined(_M_ARM64)
+    for (; (len > 0) && ((size_t)buf & ALIGN_MASK); len--, buf++) {
+        crc = __crc32cb(crc, (uint8_t)*buf);
+    }
+    for (; len >= sizeof(uint64_t); len -= sizeof(uint64_t), buf += sizeof(uint64_t)) {
+        crc = __crc32cd(crc, *(const uint64_t*)(const void*)buf);
+    }
+    for (; len >= sizeof(uint32_t); len -= sizeof(uint32_t), buf += sizeof(uint32_t)) {
+        crc = __crc32cw(crc, *(const uint32_t*)(const void*)buf);
+    }
+    for (; len >= sizeof(uint16_t); len -= sizeof(uint16_t), buf += sizeof(uint16_t)) {
+        crc = __crc32ch(crc, *(const uint16_t*)(const void*)buf);
+    }
+    for (; len > 0; len--, buf++) {
+        crc = __crc32cb(crc, (uint8_t)*buf);
+    }
+#else
+#error "HC_CRC32C_HW set for unsupported architecture"
+#endif
 #else
     {
         const uint8_t* p = (const uint8_t*)buf;

--- a/src/srclib/crc32.h
+++ b/src/srclib/crc32.h
@@ -28,11 +28,12 @@ void crc32_init(crc32_context_t* ctx);
 void crc32_update(crc32_context_t* ctx, const void* data, size_t len);
 void crc32_final(crc32_context_t* ctx, uint8_t* hash);
 
-// CRC32C (Castagnoli) is offered on x86/x86_64. With SSE4.2 / CRC32 ISA it uses
-// `_mm_crc32_*`; otherwise a software table path (needed for -mcpu=core2).
-#if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
+// CRC32C (Castagnoli): x86/x86_64 (SSE4.2 HW or software) and aarch64
+// (ARMv8 CRC32 HW when compiled with +crc, else software table).
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86) || \
+    defined(__aarch64__) || defined(_M_ARM64)
 #define HC_HAVE_CRC32C 1
-#if defined(__SSE4_2__) || defined(__CRC32__)
+#if (defined(__SSE4_2__) || defined(__CRC32__) || defined(__ARM_FEATURE_CRC32))
 #define HC_CRC32C_HW 1
 #else
 #define HC_CRC32C_HW 0

--- a/src/tests/brute_force_test.zig
+++ b/src/tests/brute_force_test.zig
@@ -113,7 +113,7 @@ fn expectMiss(algo: []const u8, s: Scenario) !void {
 
 fn runAllAlgos(s: Scenario) !void {
     for (algos) |algo| {
-        if (hashes.getHash(algo) == null) continue; // e.g. crc32c on aarch64
+        if (hashes.getHash(algo) == null) continue; // e.g. algorithm absent on this arch
         if (s.expect_found) {
             try expectFound(algo, s);
         } else {
@@ -130,7 +130,7 @@ test "BruteForce_CrackHash_RestoredStringAsSpecified" {
 
 test "BruteForce_CrackHashWithBase64TransformStep_RestoredStringAsSpecified" {
     for (algos) |algo| {
-        const h = hashes.getHash(algo) orelse continue; // e.g. crc32c on aarch64
+        const h = hashes.getHash(algo) orelse continue; // e.g. algorithm absent on this arch
         var digest: [64]u8 align(8) = std.mem.zeroes([64]u8);
         try digestOf123(h, &digest, std.testing.allocator);
         const n = h.hash_length;

--- a/src/tests/hash_test.zig
+++ b/src/tests/hash_test.zig
@@ -60,7 +60,7 @@ const cases = [_]Case{
 };
 
 fn expectHashUpper(name: []const u8, expected_upper: []const u8) !void {
-    const h = hashes.getHash(name) orelse return; // e.g. crc32c absent on aarch64
+    const h = hashes.getHash(name) orelse return; // e.g. algorithm absent on this arch
     var digest: [64]u8 align(8) = std.mem.zeroes([64]u8);
     hashes.compute(h, "123", &digest);
     var hex: [128]u8 = undefined;

--- a/windows_build.ps1
+++ b/windows_build.ps1
@@ -207,17 +207,26 @@ if ($Arch -eq "x86_64") {
     Copy-Item "$OutDir\bin\hc.exe" (Join-Path $CompatDir "hc.exe") -Force
     Copy-Item "$OutDir\bin\l2h.exe" (Join-Path $CompatDir "l2h.exe") -Force -ErrorAction SilentlyContinue
     Write-Output "==> pytest src/_tst.py  (hc -> $CompatDir\hc.exe)"
+    # Prefer real interpreters (scoop `python`) over the Windows `py` launcher:
+    # py.exe is often on PATH but prints "No installed Python found!" when no
+    # install is registered with the launcher — even if scoop python works.
     $PyLauncher = $null
-    foreach ($cand in @("py", "python3", "python")) {
+    foreach ($cand in @("python", "python3", "py")) {
         $cmd = Get-Command $cand -ErrorAction SilentlyContinue
-        if ($cmd) { $PyLauncher = $cmd.Source; break }
+        if (-not $cmd) { continue }
+        & $cmd.Source -c "import venv" 2>$null
+        if ($LASTEXITCODE -eq 0) {
+            $PyLauncher = $cmd.Source
+            Write-Output "==> Python for pytest: $PyLauncher"
+            break
+        }
     }
-    if (-not $PyLauncher) { throw "Python 3 not found (need py/python3/python for pytest black-box)" }
+    if (-not $PyLauncher) { throw "Python 3 not found (need python/python3/py with venv for pytest black-box)" }
     $VenvDir = Join-Path $ScriptDir ".venv-tst"
     $VenvPy = Join-Path $VenvDir "Scripts\python.exe"
     if (-not (Test-Path -LiteralPath $VenvPy)) {
         & $PyLauncher -m venv $VenvDir
-        if ($LASTEXITCODE -ne 0) { throw "python -m venv failed" }
+        if ($LASTEXITCODE -ne 0) { throw "python -m venv failed ($PyLauncher)" }
     }
     & $VenvPy -m pip install -q -r (Join-Path $ScriptDir "src\_tst.py\requirements.txt")
     if ($LASTEXITCODE -ne 0) { throw "pip install pytest failed" }

--- a/windows_build.ps1
+++ b/windows_build.ps1
@@ -178,8 +178,9 @@ Copy-Item "$OutDir\bin\l2h.exe" "$BinDir\l2h.exe" -Force -ErrorAction SilentlyCo
 Copy-Item "LICENSE.txt" "$BinDir\LICENSE.txt" -Force -ErrorAction SilentlyContinue
 
 # 5. Unit tests (full parity with linux_build.sh — includes brute_force_test + l2h).
-#    Capture logs under test-results/ and append Build Summary to Job Summary in CI.
-$TestFlags = @("test", "-Dtarget=$Triple")
+#    Same -Doptimize as the product build. Capture logs under test-results/ and
+#    append Build Summary to Job Summary in CI.
+$TestFlags = @("test", "-Dtarget=$Triple", "-Doptimize=$ZigOptimize")
 Write-Output "==> zig build $($TestFlags -join ' ') --summary new"
 $zigTestLog = Join-Path $TestResultsDir "zig-test.log"
 $zigTestOut = & zig build @TestFlags --summary new 2>&1
@@ -189,7 +190,7 @@ $zigTestOut | Set-Content -LiteralPath $zigTestLog -Encoding utf8
 Append-ZigSummary -Title "Zig: zig-test ($Triple)" -LogFile $zigTestLog
 if ($zigTestStatus -ne 0) { throw "zig build test failed" }
 
-$L2hTestFlags = @("test-l2h", "-Dtarget=$Triple")
+$L2hTestFlags = @("test-l2h", "-Dtarget=$Triple", "-Doptimize=$ZigOptimize")
 Write-Output "==> zig build $($L2hTestFlags -join ' ') --summary new"
 $zigL2hLog = Join-Path $TestResultsDir "zig-test-l2h.log"
 $zigL2hOut = & zig build @L2hTestFlags --summary new 2>&1

--- a/windows_build.ps1
+++ b/windows_build.ps1
@@ -8,8 +8,9 @@
 
 .DESCRIPTION
   Provisioning: scripts/build_external_libs.ps1 downloads/builds OpenSSL
-  (static libcrypto + headers) on first run (optional seed from C:\external_lib /
-  HC_EXTERNAL_LIB_CACHE when present). Idempotent afterwards.
+  (static libcrypto + headers) into the workspace and writes back a
+  versioned tree under C:\external_lib / HC_EXTERNAL_LIB_CACHE so the next
+  CI job can seed without rebuilding. Idempotent afterwards.
 
   C dependencies are prebuilt MSVC COFF artifacts; the build targets
   x86_64-windows-msvc so lld-link can link them. CUDA is required for GPU


### PR DESCRIPTION
Move aarch64-linux-musl off the x64 matrix onto self-hosted linux ARM64 and enable unit/pytest when the target matches the host arch.