### PR TITLE
fix(gpu): repair OpenCL crack path and avoid heavy-kernel regressions

### DIFF
--- a/src/abi/gpu_abi.h
+++ b/src/abi/gpu_abi.h
@@ -84,6 +84,8 @@ void gpu_get_props(device_props_t* prop);
 /** Launch geometry for a single device (not summed across GPUs). */
 BOOL gpu_get_device_props(int device_ix, device_props_t* prop);
 BOOL gpu_can_use_gpu(void);
+/** True when the selected backend is OpenCL (not CUDA / stub). */
+BOOL gpu_is_opencl(void);
 int gpu_driver_version(void);
 int gpu_runtime_version(void);
 gpu_versions_t gpu_number_to_version(int version_number);
@@ -121,7 +123,7 @@ void gpu_cleanup(gpu_tread_ctx_t* ctx);
 #define GPU_STREAM(ctx) ((cudaStream_t)((ctx)->stream_))
 #endif
 
- /* Prefix index + 1-char expand (cpi=1). min_len is passmin — skip shorter hits. */
+ /* Prefix index + 2-char expand (cpi=2, md5-style). min_len is passmin. */
 #ifndef KERNEL_WITHOUT_ALLOCATION
 #define KERNEL_WITHOUT_ALLOCATION(func_name, compare_func)                                              \
 __global__ void func_name(unsigned char* result, const uint64_t start, const uint32_t count,            \
@@ -134,17 +136,21 @@ __global__ void func_name(unsigned char* result, const uint64_t start, const uin
         attempt[pos] = k_dict[idx % dict_length];                                                       \
         idx /= dict_length;                                                                             \
     }                                                                                                   \
-    if (pass_len >= min_len && compare_func(attempt, (int)pass_len)) {                                  \
-        memcpy(result, attempt, pass_len);                                                              \
-        return;                                                                                         \
-    }                                                                                                   \
-    const uint32_t attempt_len = pass_len + 1u;                                                         \
-    if (attempt_len < min_len) return;                                                                  \
     for (uint32_t i = 0; i < dict_length; ++i) {                                                        \
         attempt[pass_len] = k_dict[i];                                                                  \
-        if (compare_func(attempt, (int)attempt_len)) {                                                  \
-            memcpy(result, attempt, attempt_len);                                                       \
-            return;                                                                                     \
+        if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {                                          \
+            if (compare_func(attempt, (int)(pass_len + 1u))) {                                          \
+                memcpy(result, attempt, pass_len + 1u);                                                 \
+                return;                                                                                 \
+            }                                                                                           \
+        }                                                                                               \
+        if (pass_len + 2u < min_len) continue;                                                          \
+        for (uint32_t j = 0; j < dict_length; ++j) {                                                    \
+            attempt[pass_len + 1u] = k_dict[j];                                                         \
+            if (compare_func(attempt, (int)(pass_len + 2u))) {                                          \
+                memcpy(result, attempt, pass_len + 2u);                                                 \
+                return;                                                                                 \
+            }                                                                                           \
         }                                                                                               \
     }                                                                                                   \
 }
@@ -163,17 +169,21 @@ __global__ void func_name(unsigned char* result, const uint64_t start, const uin
         attempt[pos] = k_dict[idx % dict_length];                                                       \
         idx /= dict_length;                                                                             \
     }                                                                                                   \
-    if (pass_len >= min_len && compare_func(attempt, (int)pass_len, hash)) {                            \
-        memcpy(result, attempt, pass_len);                                                              \
-        return;                                                                                         \
-    }                                                                                                   \
-    const uint32_t attempt_len = pass_len + 1u;                                                         \
-    if (attempt_len < min_len) return;                                                                  \
     for (uint32_t i = 0; i < dict_length; ++i) {                                                        \
         attempt[pass_len] = k_dict[i];                                                                  \
-        if (compare_func(attempt, (int)attempt_len, hash)) {                                            \
-            memcpy(result, attempt, attempt_len);                                                       \
-            return;                                                                                     \
+        if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {                                          \
+            if (compare_func(attempt, (int)(pass_len + 1u), hash)) {                                    \
+                memcpy(result, attempt, pass_len + 1u);                                                 \
+                return;                                                                                 \
+            }                                                                                           \
+        }                                                                                               \
+        if (pass_len + 2u < min_len) continue;                                                          \
+        for (uint32_t j = 0; j < dict_length; ++j) {                                                    \
+            attempt[pass_len + 1u] = k_dict[j];                                                         \
+            if (compare_func(attempt, (int)(pass_len + 2u), hash)) {                                    \
+                memcpy(result, attempt, pass_len + 2u);                                                 \
+                return;                                                                                 \
+            }                                                                                           \
         }                                                                                               \
     }                                                                                                   \
 }

--- a/src/cuda/cuda_prefix.h
+++ b/src/cuda/cuda_prefix.h
@@ -5,6 +5,7 @@
 #define gpu_get_props cuda_gpu_get_props
 #define gpu_get_device_props cuda_gpu_get_device_props
 #define gpu_can_use_gpu cuda_gpu_can_use_gpu
+#define gpu_is_opencl cuda_gpu_is_opencl
 #define gpu_driver_version cuda_gpu_driver_version
 #define gpu_runtime_version cuda_gpu_runtime_version
 #define gpu_number_to_version cuda_gpu_number_to_version

--- a/src/cuda/gpu.cu
+++ b/src/cuda/gpu.cu
@@ -114,6 +114,10 @@ BOOL gpu_can_use_gpu() {
     return TRUE;
 }
 
+BOOL gpu_is_opencl(void) {
+    return FALSE;
+}
+
 int gpu_driver_version() {
     int ver;
     const cudaError_t err = cudaDriverGetVersion(&ver);

--- a/src/cuda/md2.cu
+++ b/src/cuda/md2.cu
@@ -158,22 +158,22 @@ __global__ void prmd2_kernel(unsigned char* result, const uint64_t start, const 
         idx /= dict_length;
     }
 
-    if (pass_len >= min_len && prmd2_hash_eq(attempt, (int)pass_len, s_sbox)) {
-        memcpy(result, attempt, pass_len);
-        return;
-    }
-
-    const uint32_t attempt_len = pass_len + 1u;
-    /* One-shot path requires length < 16 (GPU max password is GPU_ATTEMPT_SIZE-1). */
-    if (attempt_len < min_len || attempt_len >= DIGESTSIZE) {
-        return;
-    }
-
     for (uint32_t i = 0; i < dict_length; ++i) {
         attempt[pass_len] = k_dict[i];
-        if (prmd2_hash_eq(attempt, (int)attempt_len, s_sbox)) {
-            memcpy(result, attempt, attempt_len);
-            return;
+        if (pass_len + 1u == 4u && pass_len + 1u >= min_len && pass_len + 1u < DIGESTSIZE) {
+            if (prmd2_hash_eq(attempt, (int)(pass_len + 1u), s_sbox)) {
+                memcpy(result, attempt, pass_len + 1u);
+                return;
+            }
+        }
+        /* One-shot path requires length < 16 (GPU max password is GPU_ATTEMPT_SIZE-1). */
+        if (pass_len + 2u < min_len || pass_len + 2u >= DIGESTSIZE) continue;
+        for (uint32_t j = 0; j < dict_length; ++j) {
+            attempt[pass_len + 1u] = k_dict[j];
+            if (prmd2_hash_eq(attempt, (int)(pass_len + 2u), s_sbox)) {
+                memcpy(result, attempt, pass_len + 2u);
+                return;
+            }
         }
     }
 }

--- a/src/cuda/sha3.cu
+++ b/src/cuda/sha3.cu
@@ -170,17 +170,21 @@ __global__ static void pr##name##_kernel(unsigned char* result, const uint64_t s
         attempt[pos] = k_dict[idx % dict_length];                                                        \
         idx /= dict_length;                                                                              \
     }                                                                                                    \
-    if (pass_len >= min_len && pr##name##_compare(attempt, (int)pass_len, hash)) {                       \
-        memcpy(result, attempt, pass_len);                                                               \
-        return;                                                                                          \
-    }                                                                                                    \
-    const uint32_t attempt_len = pass_len + 1u;                                                          \
-    if (attempt_len < min_len) return;                                                                   \
     for (uint32_t i = 0; i < dict_length; ++i) {                                                         \
         attempt[pass_len] = k_dict[i];                                                                   \
-        if (pr##name##_compare(attempt, (int)attempt_len, hash)) {                                       \
-            memcpy(result, attempt, attempt_len);                                                        \
-            return;                                                                                      \
+        if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {                                           \
+            if (pr##name##_compare(attempt, (int)(pass_len + 1u), hash)) {                               \
+                memcpy(result, attempt, pass_len + 1u);                                                  \
+                return;                                                                                  \
+            }                                                                                            \
+        }                                                                                                \
+        if (pass_len + 2u < min_len) continue;                                                           \
+        for (uint32_t j = 0; j < dict_length; ++j) {                                                     \
+            attempt[pass_len + 1u] = k_dict[j];                                                          \
+            if (pr##name##_compare(attempt, (int)(pass_len + 2u), hash)) {                               \
+                memcpy(result, attempt, pass_len + 2u);                                                  \
+                return;                                                                                  \
+            }                                                                                            \
         }                                                                                                \
     }                                                                                                    \
 }                                                                                                        \

--- a/src/hc/bf.zig
+++ b/src/hc/bf.zig
@@ -364,9 +364,13 @@ fn runBruteForce(
 
     // Lengths 1..=3 crack instantly on CPU; GPU is overkill there.
     // Enable GPU only when passmax > 3 (same gate as classic).
-    // While GPU runs, keep exactly one CPU thread (intentional: avoid fighting
-    // the device for host cores; CPU still covers lengths above the GPU slot).
     var has_gpu = has_gpu_in and passmax > 3;
+    const gpu_factor: c_int = if (gpu_context) |gc| gc.max_threads_decrease_factor_ else 1;
+    // OpenCL-only builds: heavy kernels (factor >= 4) lose short cracks to
+    // multi-CPU and load a large runtime — skip GPU before any device probe.
+    if (has_gpu and gpu_factor >= 4 and gpu.enable_opencl and !gpu.enable_cuda) {
+        has_gpu = false;
+    }
     if (has_gpu and !c.gpu_can_use_gpu()) {
         // Leading newline: probe estimate is printed without a trailing '\n'
         // (outputTimings supplies it). Without this, the diagnostic would glue
@@ -384,14 +388,16 @@ fn runBruteForce(
     }
     const gpu_max_len: u32 = gpuMaxPasswordLen();
 
-    // Light GPU kernels (decrease_factor 1–2) beat multi-CPU; keep one host
-    // thread so we do not fight the device. Heavy kernels (factor >= 4: tiger,
-    // whirlpool, sha384/512) can be slower than multi-CPU for short cracks —
-    // keep the caller's thread count so a slow GPU cannot regress wall time.
+    // Light kernels (factor 1–2) beat multi-CPU on GPU — pin to 1 host thread.
+    // Heavy kernels (factor >= 4): on OpenCL (dual binary that fell back to CL)
+    // skip GPU so wall time matches classic multi-CPU; CUDA keeps GPU + threads.
     var num_threads: u32 = num_threads_in;
     if (has_gpu) {
-        const dec = if (gpu_context) |gc| gc.max_threads_decrease_factor_ else 1;
-        if (dec < 4) num_threads = 1;
+        if (gpu_factor >= 4 and c.gpu_is_opencl()) {
+            has_gpu = false;
+        } else if (gpu_factor < 4) {
+            num_threads = 1;
+        }
     }
 
     const prepared = try prepareDictionary(arena, dict);

--- a/src/hc/bf_core.c
+++ b/src/hc/bf_core.c
@@ -94,10 +94,14 @@ void bf_core_gpu_worker(gpu_tread_ctx_t *ctx) {
     /* Max prefix slots per launch = grid capacity (blocks * threads). */
     uint64_t max_batch =
         (uint64_t)ctx->max_gpu_blocks_number_ * (uint64_t)ctx->max_threads_per_block_;
-    /* Heavy kernels (factor >= 4): cap launch size so a CPU hit is noticed soon
-     * after the current kernel — otherwise one long grid blocks wall time. */
-    if (ctx->max_threads_decrease_factor_ >= 4 && max_batch > 262144ull) {
-        max_batch = 262144ull;
+    /* Soft cap for light kernels (md5/md4/…). Heavy kernels (factor >= 2)
+     * do far more work per WI; long NDRanges on some OpenCL devices are
+     * killed/truncated (missed hits) and also block the host in clFinish so a
+     * parallel CPU hit is invisible until the kernel ends. Keep launches short. */
+    const uint64_t batch_cap =
+        (ctx->max_threads_decrease_factor_ >= 2) ? 4096ull : 262144ull;
+    if (max_batch > batch_cap) {
+        max_batch = batch_cap;
     }
 
     if (!gpu_init_pipeline(ctx)) {
@@ -115,12 +119,15 @@ void bf_core_gpu_worker(gpu_tread_ctx_t *ctx) {
 
     /* Classic GPU model: walk prefix lengths, kernel expands last cpi chars.
      * pass_length_ is the PREFIX length; full password = prefix + cpi.
-     * Lengths 1..=3 stay on CPU (bf.zig enables GPU only when passmax > 3);
-     * GPU always starts at plen 3. cpi==0: exact-length only (no expand).
+     * Lengths 1..=3 stay on CPU (bf.zig enables GPU only when passmax > 3).
+     * cpi==2 (md5/blake2/sha3/…): start plen 3 → covers lengths 4 and 5 in the
+     * first launch. cpi==1 (legacy 1-char expand): start plen 4 so the first
+     * launch can hit length 5 without a wasted dict^3 grid. cpi==0: exact-length
+     * only (no expand), start at 3.
      * `decrease` is signed: factor 1→2, 2→1, 4→-1 (prefix_max = passmax+1).
      * Do not use uint32_t subtraction — factor 4 would wrap to UINT32_MAX. */
     const int cpi = ctx->comparisons_per_iteration_;
-    const uint32_t pass_min = 3;
+    const uint32_t pass_min = (cpi == 1) ? 4u : 3u;
     uint32_t prefix_max;
     if (cpi == 0) {
         prefix_max = ctx->passmax_;

--- a/src/hc/gpu.zig
+++ b/src/hc/gpu.zig
@@ -67,33 +67,38 @@ fn gpuEntry(
 
 /// Algorithms that ship with a CUDA implementation.
 const gpu_algos = [_]GpuAlgoEntry{
+    // factor / comparisons_per_iteration (cpi): cpi=2 expands two suffix chars
+    // per prefix (md5-style) so plen=3 covers lengths 4 and 5 in the first launch.
     gpuEntry("md5", @ptrCast(&c.md5_run_on_gpu), @ptrCast(&c.md5_on_gpu_prepare), 1, 2),
     gpuEntry("sha1", @ptrCast(&c.sha1_run_on_gpu), @ptrCast(&c.sha1_on_gpu_prepare), 1, 2),
-    gpuEntry("sha256", @ptrCast(&c.sha256_run_on_gpu), @ptrCast(&c.sha256_on_gpu_prepare), 2, 1),
-    gpuEntry("sha224", @ptrCast(&c.sha224_run_on_gpu), @ptrCast(&c.sha224_on_gpu_prepare), 2, 1),
-    gpuEntry("sha-3-224", @ptrCast(&c.sha3_224_run_on_gpu), @ptrCast(&c.sha3_224_on_gpu_prepare), 4, 1),
-    gpuEntry("sha-3-256", @ptrCast(&c.sha3_256_run_on_gpu), @ptrCast(&c.sha3_256_on_gpu_prepare), 4, 1),
-    gpuEntry("sha-3-384", @ptrCast(&c.sha3_384_run_on_gpu), @ptrCast(&c.sha3_384_on_gpu_prepare), 4, 1),
-    gpuEntry("sha-3-512", @ptrCast(&c.sha3_512_run_on_gpu), @ptrCast(&c.sha3_512_on_gpu_prepare), 4, 1),
-    gpuEntry("sha-3k-224", @ptrCast(&c.keccak_224_run_on_gpu), @ptrCast(&c.keccak_224_on_gpu_prepare), 4, 1),
-    gpuEntry("sha-3k-256", @ptrCast(&c.keccak_256_run_on_gpu), @ptrCast(&c.keccak_256_on_gpu_prepare), 4, 1),
-    gpuEntry("sha-3k-384", @ptrCast(&c.keccak_384_run_on_gpu), @ptrCast(&c.keccak_384_on_gpu_prepare), 4, 1),
-    gpuEntry("sha-3k-512", @ptrCast(&c.keccak_512_run_on_gpu), @ptrCast(&c.keccak_512_on_gpu_prepare), 4, 1),
-    gpuEntry("sha384", @ptrCast(&c.sha384_run_on_gpu), @ptrCast(&c.sha384_on_gpu_prepare), 4, 1),
-    gpuEntry("sha512", @ptrCast(&c.sha512_run_on_gpu), @ptrCast(&c.sha512_on_gpu_prepare), 4, 1),
-    gpuEntry("md2", @ptrCast(&c.md2_run_on_gpu), @ptrCast(&c.md2_on_gpu_prepare), 2, 1),
+    gpuEntry("sha256", @ptrCast(&c.sha256_run_on_gpu), @ptrCast(&c.sha256_on_gpu_prepare), 2, 2),
+    gpuEntry("sha224", @ptrCast(&c.sha224_run_on_gpu), @ptrCast(&c.sha224_on_gpu_prepare), 2, 2),
+    // factor 4: on OpenCL these lose short cracks to multi-CPU (and contend on
+    // iGPU); bf.zig skips GPU for OpenCL+factor>=4. CUDA still runs them on GPU.
+    gpuEntry("sha-3-224", @ptrCast(&c.sha3_224_run_on_gpu), @ptrCast(&c.sha3_224_on_gpu_prepare), 4, 2),
+    gpuEntry("sha-3-256", @ptrCast(&c.sha3_256_run_on_gpu), @ptrCast(&c.sha3_256_on_gpu_prepare), 4, 2),
+    gpuEntry("sha-3-384", @ptrCast(&c.sha3_384_run_on_gpu), @ptrCast(&c.sha3_384_on_gpu_prepare), 4, 2),
+    gpuEntry("sha-3-512", @ptrCast(&c.sha3_512_run_on_gpu), @ptrCast(&c.sha3_512_on_gpu_prepare), 4, 2),
+    gpuEntry("sha-3k-224", @ptrCast(&c.keccak_224_run_on_gpu), @ptrCast(&c.keccak_224_on_gpu_prepare), 4, 2),
+    gpuEntry("sha-3k-256", @ptrCast(&c.keccak_256_run_on_gpu), @ptrCast(&c.keccak_256_on_gpu_prepare), 4, 2),
+    gpuEntry("sha-3k-384", @ptrCast(&c.keccak_384_run_on_gpu), @ptrCast(&c.keccak_384_on_gpu_prepare), 4, 2),
+    gpuEntry("sha-3k-512", @ptrCast(&c.keccak_512_run_on_gpu), @ptrCast(&c.keccak_512_on_gpu_prepare), 4, 2),
+    gpuEntry("sha384", @ptrCast(&c.sha384_run_on_gpu), @ptrCast(&c.sha384_on_gpu_prepare), 4, 2),
+    gpuEntry("sha512", @ptrCast(&c.sha512_run_on_gpu), @ptrCast(&c.sha512_on_gpu_prepare), 4, 2),
+    gpuEntry("md2", @ptrCast(&c.md2_run_on_gpu), @ptrCast(&c.md2_on_gpu_prepare), 4, 2),
     gpuEntry("md4", @ptrCast(&c.md4_run_on_gpu), @ptrCast(&c.md4_on_gpu_prepare), 1, 2),
     gpuEntry("ntlm", @ptrCast(&c.md4_run_on_gpu), @ptrCast(&c.md4_on_gpu_prepare), 1, 2),
-    gpuEntry("ripemd128", @ptrCast(&c.rmd128_run_on_gpu), @ptrCast(&c.rmd128_on_gpu_prepare), 2, 1),
-    gpuEntry("ripemd160", @ptrCast(&c.rmd160_run_on_gpu), @ptrCast(&c.rmd160_on_gpu_prepare), 2, 1),
-    gpuEntry("ripemd256", @ptrCast(&c.rmd256_run_on_gpu), @ptrCast(&c.rmd256_on_gpu_prepare), 2, 1),
-    gpuEntry("ripemd320", @ptrCast(&c.rmd320_run_on_gpu), @ptrCast(&c.rmd320_on_gpu_prepare), 2, 1),
-    gpuEntry("blake2s", @ptrCast(&c.blake2s_run_on_gpu), @ptrCast(&c.blake2s_on_gpu_prepare), 2, 1),
-    gpuEntry("blake2b", @ptrCast(&c.blake2b_run_on_gpu), @ptrCast(&c.blake2b_on_gpu_prepare), 4, 1),
-    // factor>=4 keeps multi-CPU; cpi=0 = exact-length kernel (no serial expand).
+    gpuEntry("ripemd128", @ptrCast(&c.rmd128_run_on_gpu), @ptrCast(&c.rmd128_on_gpu_prepare), 4, 2),
+    gpuEntry("ripemd160", @ptrCast(&c.rmd160_run_on_gpu), @ptrCast(&c.rmd160_on_gpu_prepare), 4, 2),
+    gpuEntry("ripemd256", @ptrCast(&c.rmd256_run_on_gpu), @ptrCast(&c.rmd256_on_gpu_prepare), 4, 2),
+    gpuEntry("ripemd320", @ptrCast(&c.rmd320_run_on_gpu), @ptrCast(&c.rmd320_on_gpu_prepare), 4, 2),
+    gpuEntry("blake2s", @ptrCast(&c.blake2s_run_on_gpu), @ptrCast(&c.blake2s_on_gpu_prepare), 4, 2),
+    gpuEntry("blake2b", @ptrCast(&c.blake2b_run_on_gpu), @ptrCast(&c.blake2b_on_gpu_prepare), 4, 2),
+    // cpi=0 = exact-length kernel (no serial expand). factor 4 keeps multi-CPU
+    // as a floor for tiger (heavy exact-length search).
     gpuEntry("tiger", @ptrCast(&c.tiger_run_on_gpu), @ptrCast(&c.tiger_on_gpu_prepare), 4, 0),
     gpuEntry("tiger2", @ptrCast(&c.tiger2_run_on_gpu), @ptrCast(&c.tiger2_on_gpu_prepare), 4, 0),
-    gpuEntry("whirlpool", @ptrCast(&c.whirl_run_on_gpu), @ptrCast(&c.whirl_on_gpu_prepare), 4, 1),
+    gpuEntry("whirlpool", @ptrCast(&c.whirl_run_on_gpu), @ptrCast(&c.whirl_on_gpu_prepare), 4, 2),
     gpuEntry("crc32", @ptrCast(&c.crc32_run_on_gpu), @ptrCast(&c.crc32_on_gpu_prepare), 1, 2),
 };
 
@@ -116,13 +121,15 @@ test "contextFor known algorithms" {
     try std.testing.expect(md5.pfn_prepare_ != null);
     try std.testing.expectEqual(@as(c_int, 1), md5.max_threads_decrease_factor_);
     try std.testing.expect(contextFor("ripemd128") != null);
-    try std.testing.expectEqual(@as(c_int, 2), contextFor("ripemd128").?.max_threads_decrease_factor_);
+    try std.testing.expectEqual(@as(c_int, 4), contextFor("ripemd128").?.max_threads_decrease_factor_);
     try std.testing.expect(contextFor("ripemd256") != null);
     try std.testing.expect(contextFor("ripemd320") != null);
     try std.testing.expect(contextFor("blake2s") != null);
     try std.testing.expect(contextFor("blake2b") != null);
     try std.testing.expectEqual(@as(c_int, 4), contextFor("blake2b").?.max_threads_decrease_factor_);
     try std.testing.expect(contextFor("sha-3-256") != null);
+    try std.testing.expectEqual(@as(c_int, 4), contextFor("sha-3-256").?.max_threads_decrease_factor_);
+    try std.testing.expectEqual(@as(c_int, 2), contextFor("sha-3-256").?.comparisons_per_iteration_);
     try std.testing.expect(contextFor("sha-3k-256") != null);
     try std.testing.expect(contextFor("tiger") != null);
     try std.testing.expectEqual(@as(c_int, 4), contextFor("tiger").?.max_threads_decrease_factor_);

--- a/src/hc/gpu_dispatch.c
+++ b/src/hc/gpu_dispatch.c
@@ -13,6 +13,10 @@ BOOL gpu_can_use_gpu(void) {
     return pick_backend() != HC_GPU_NONE ? TRUE : FALSE;
 }
 
+BOOL gpu_is_opencl(void) {
+    return pick_backend() == HC_GPU_OPENCL;
+}
+
 void gpu_get_props(device_props_t* prop) {
     if (cuda_gpu_can_use_gpu()) cuda_gpu_get_props(prop);
     else ocl_gpu_get_props(prop);

--- a/src/hc/gpu_stub.c
+++ b/src/hc/gpu_stub.c
@@ -24,6 +24,10 @@ BOOL gpu_can_use_gpu(void) {
     return FALSE;
 }
 
+BOOL gpu_is_opencl(void) {
+    return FALSE;
+}
+
 int gpu_driver_version(void) {
     return 0;
 }

--- a/src/opencl/kernels/blake2b.cl
+++ b/src/opencl/kernels/blake2b.cl
@@ -128,25 +128,27 @@ __kernel void prblake2b_kernel(__global uchar* result,
     attempt[pos] = k_dict[idx % dict_length];
     idx /= dict_length;
   }
-  if (pass_len >= min_len) {
-    if (*g_found) return;
-    if (prblake2b_compare(k_hash, attempt, (int)pass_len)) {
-      for (uint k = 0; k < pass_len; ++k) result[k] = attempt[k];
-      result[pass_len] = 0;
-      *g_found = 1;
-      return;
-    }
-  }
-  const uint attempt_len = pass_len + 1u;
-  if (attempt_len < min_len) return;
   for (uint i = 0; i < dict_length; ++i) {
     attempt[pass_len] = k_dict[i];
-    if (*g_found) return;
-    if (prblake2b_compare(k_hash, attempt, (int)attempt_len)) {
-      for (uint k = 0; k < attempt_len; ++k) result[k] = attempt[k];
-      result[attempt_len] = 0;
-      *g_found = 1;
-      return;
+    if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {
+      if (*g_found) return;
+      if (prblake2b_compare(k_hash, attempt, (int)(pass_len + 1u))) {
+        for (uint k = 0; k < pass_len + 1u; ++k) result[k] = attempt[k];
+        result[pass_len + 1u] = 0;
+        *g_found = 1;
+        return;
+      }
+    }
+    if (pass_len + 2u < min_len) continue;
+    for (uint j = 0; j < dict_length; ++j) {
+      attempt[pass_len + 1u] = k_dict[j];
+      if (*g_found) return;
+      if (prblake2b_compare(k_hash, attempt, (int)(pass_len + 2u))) {
+        for (uint k = 0; k < pass_len + 2u; ++k) result[k] = attempt[k];
+        result[pass_len + 2u] = 0;
+        *g_found = 1;
+        return;
+      }
     }
   }
 }

--- a/src/opencl/kernels/blake2b.cl.h
+++ b/src/opencl/kernels/blake2b.cl.h
@@ -128,25 +128,27 @@
 "    attempt[pos] = k_dict[idx % dict_length];\n"\
 "    idx /= dict_length;\n"\
 "  }\n"\
-"  if (pass_len >= min_len) {\n"\
-"    if (*g_found) return;\n"\
-"    if (prblake2b_compare(k_hash, attempt, (int)pass_len)) {\n"\
-"      for (uint k = 0; k < pass_len; ++k) result[k] = attempt[k];\n"\
-"      result[pass_len] = 0;\n"\
-"      *g_found = 1;\n"\
-"      return;\n"\
-"    }\n"\
-"  }\n"\
-"  const uint attempt_len = pass_len + 1u;\n"\
-"  if (attempt_len < min_len) return;\n"\
 "  for (uint i = 0; i < dict_length; ++i) {\n"\
 "    attempt[pass_len] = k_dict[i];\n"\
-"    if (*g_found) return;\n"\
-"    if (prblake2b_compare(k_hash, attempt, (int)attempt_len)) {\n"\
-"      for (uint k = 0; k < attempt_len; ++k) result[k] = attempt[k];\n"\
-"      result[attempt_len] = 0;\n"\
-"      *g_found = 1;\n"\
-"      return;\n"\
+"    if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {\n"\
+"      if (*g_found) return;\n"\
+"      if (prblake2b_compare(k_hash, attempt, (int)(pass_len + 1u))) {\n"\
+"        for (uint k = 0; k < pass_len + 1u; ++k) result[k] = attempt[k];\n"\
+"        result[pass_len + 1u] = 0;\n"\
+"        *g_found = 1;\n"\
+"        return;\n"\
+"      }\n"\
+"    }\n"\
+"    if (pass_len + 2u < min_len) continue;\n"\
+"    for (uint j = 0; j < dict_length; ++j) {\n"\
+"      attempt[pass_len + 1u] = k_dict[j];\n"\
+"      if (*g_found) return;\n"\
+"      if (prblake2b_compare(k_hash, attempt, (int)(pass_len + 2u))) {\n"\
+"        for (uint k = 0; k < pass_len + 2u; ++k) result[k] = attempt[k];\n"\
+"        result[pass_len + 2u] = 0;\n"\
+"        *g_found = 1;\n"\
+"        return;\n"\
+"      }\n"\
 "    }\n"\
 "  }\n"\
-"}\n"
+"}\n"\

--- a/src/opencl/kernels/blake2s.cl
+++ b/src/opencl/kernels/blake2s.cl
@@ -116,25 +116,27 @@ __kernel void prblake2s_kernel(__global uchar* result,
     attempt[pos] = k_dict[idx % dict_length];
     idx /= dict_length;
   }
-  if (pass_len >= min_len) {
-    if (*g_found) return;
-    if (prblake2s_compare(k_hash, attempt, (int)pass_len)) {
-      for (uint k = 0; k < pass_len; ++k) result[k] = attempt[k];
-      result[pass_len] = 0;
-      *g_found = 1;
-      return;
-    }
-  }
-  const uint attempt_len = pass_len + 1u;
-  if (attempt_len < min_len) return;
   for (uint i = 0; i < dict_length; ++i) {
     attempt[pass_len] = k_dict[i];
-    if (*g_found) return;
-    if (prblake2s_compare(k_hash, attempt, (int)attempt_len)) {
-      for (uint k = 0; k < attempt_len; ++k) result[k] = attempt[k];
-      result[attempt_len] = 0;
-      *g_found = 1;
-      return;
+    if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {
+      if (*g_found) return;
+      if (prblake2s_compare(k_hash, attempt, (int)(pass_len + 1u))) {
+        for (uint k = 0; k < pass_len + 1u; ++k) result[k] = attempt[k];
+        result[pass_len + 1u] = 0;
+        *g_found = 1;
+        return;
+      }
+    }
+    if (pass_len + 2u < min_len) continue;
+    for (uint j = 0; j < dict_length; ++j) {
+      attempt[pass_len + 1u] = k_dict[j];
+      if (*g_found) return;
+      if (prblake2s_compare(k_hash, attempt, (int)(pass_len + 2u))) {
+        for (uint k = 0; k < pass_len + 2u; ++k) result[k] = attempt[k];
+        result[pass_len + 2u] = 0;
+        *g_found = 1;
+        return;
+      }
     }
   }
 }

--- a/src/opencl/kernels/blake2s.cl.h
+++ b/src/opencl/kernels/blake2s.cl.h
@@ -116,25 +116,27 @@
 "    attempt[pos] = k_dict[idx % dict_length];\n"\
 "    idx /= dict_length;\n"\
 "  }\n"\
-"  if (pass_len >= min_len) {\n"\
-"    if (*g_found) return;\n"\
-"    if (prblake2s_compare(k_hash, attempt, (int)pass_len)) {\n"\
-"      for (uint k = 0; k < pass_len; ++k) result[k] = attempt[k];\n"\
-"      result[pass_len] = 0;\n"\
-"      *g_found = 1;\n"\
-"      return;\n"\
-"    }\n"\
-"  }\n"\
-"  const uint attempt_len = pass_len + 1u;\n"\
-"  if (attempt_len < min_len) return;\n"\
 "  for (uint i = 0; i < dict_length; ++i) {\n"\
 "    attempt[pass_len] = k_dict[i];\n"\
-"    if (*g_found) return;\n"\
-"    if (prblake2s_compare(k_hash, attempt, (int)attempt_len)) {\n"\
-"      for (uint k = 0; k < attempt_len; ++k) result[k] = attempt[k];\n"\
-"      result[attempt_len] = 0;\n"\
-"      *g_found = 1;\n"\
-"      return;\n"\
+"    if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {\n"\
+"      if (*g_found) return;\n"\
+"      if (prblake2s_compare(k_hash, attempt, (int)(pass_len + 1u))) {\n"\
+"        for (uint k = 0; k < pass_len + 1u; ++k) result[k] = attempt[k];\n"\
+"        result[pass_len + 1u] = 0;\n"\
+"        *g_found = 1;\n"\
+"        return;\n"\
+"      }\n"\
+"    }\n"\
+"    if (pass_len + 2u < min_len) continue;\n"\
+"    for (uint j = 0; j < dict_length; ++j) {\n"\
+"      attempt[pass_len + 1u] = k_dict[j];\n"\
+"      if (*g_found) return;\n"\
+"      if (prblake2s_compare(k_hash, attempt, (int)(pass_len + 2u))) {\n"\
+"        for (uint k = 0; k < pass_len + 2u; ++k) result[k] = attempt[k];\n"\
+"        result[pass_len + 2u] = 0;\n"\
+"        *g_found = 1;\n"\
+"        return;\n"\
+"      }\n"\
 "    }\n"\
 "  }\n"\
-"}\n"
+"}\n"\

--- a/src/opencl/kernels/keccak_224.cl
+++ b/src/opencl/kernels/keccak_224.cl
@@ -149,25 +149,27 @@ __kernel void prkeccak_224_kernel(__global uchar* result,
     attempt[pos] = k_dict[idx % dict_length];
     idx /= dict_length;
   }
-  if (pass_len >= min_len) {
-    if (*g_found) return;
-    if (prkeccak_224_compare(k_hash, attempt, (int)pass_len)) {
-      for (uint k = 0; k < pass_len; ++k) result[k] = attempt[k];
-      result[pass_len] = 0;
-      *g_found = 1;
-      return;
-    }
-  }
-  const uint attempt_len = pass_len + 1u;
-  if (attempt_len < min_len) return;
   for (uint i = 0; i < dict_length; ++i) {
     attempt[pass_len] = k_dict[i];
-    if (*g_found) return;
-    if (prkeccak_224_compare(k_hash, attempt, (int)attempt_len)) {
-      for (uint k = 0; k < attempt_len; ++k) result[k] = attempt[k];
-      result[attempt_len] = 0;
-      *g_found = 1;
-      return;
+    if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {
+      if (*g_found) return;
+      if (prkeccak_224_compare(k_hash, attempt, (int)(pass_len + 1u))) {
+        for (uint k = 0; k < pass_len + 1u; ++k) result[k] = attempt[k];
+        result[pass_len + 1u] = 0;
+        *g_found = 1;
+        return;
+      }
+    }
+    if (pass_len + 2u < min_len) continue;
+    for (uint j = 0; j < dict_length; ++j) {
+      attempt[pass_len + 1u] = k_dict[j];
+      if (*g_found) return;
+      if (prkeccak_224_compare(k_hash, attempt, (int)(pass_len + 2u))) {
+        for (uint k = 0; k < pass_len + 2u; ++k) result[k] = attempt[k];
+        result[pass_len + 2u] = 0;
+        *g_found = 1;
+        return;
+      }
     }
   }
 }

--- a/src/opencl/kernels/keccak_224.cl.h
+++ b/src/opencl/kernels/keccak_224.cl.h
@@ -149,25 +149,27 @@
 "    attempt[pos] = k_dict[idx % dict_length];\n"\
 "    idx /= dict_length;\n"\
 "  }\n"\
-"  if (pass_len >= min_len) {\n"\
-"    if (*g_found) return;\n"\
-"    if (prkeccak_224_compare(k_hash, attempt, (int)pass_len)) {\n"\
-"      for (uint k = 0; k < pass_len; ++k) result[k] = attempt[k];\n"\
-"      result[pass_len] = 0;\n"\
-"      *g_found = 1;\n"\
-"      return;\n"\
-"    }\n"\
-"  }\n"\
-"  const uint attempt_len = pass_len + 1u;\n"\
-"  if (attempt_len < min_len) return;\n"\
 "  for (uint i = 0; i < dict_length; ++i) {\n"\
 "    attempt[pass_len] = k_dict[i];\n"\
-"    if (*g_found) return;\n"\
-"    if (prkeccak_224_compare(k_hash, attempt, (int)attempt_len)) {\n"\
-"      for (uint k = 0; k < attempt_len; ++k) result[k] = attempt[k];\n"\
-"      result[attempt_len] = 0;\n"\
-"      *g_found = 1;\n"\
-"      return;\n"\
+"    if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {\n"\
+"      if (*g_found) return;\n"\
+"      if (prkeccak_224_compare(k_hash, attempt, (int)(pass_len + 1u))) {\n"\
+"        for (uint k = 0; k < pass_len + 1u; ++k) result[k] = attempt[k];\n"\
+"        result[pass_len + 1u] = 0;\n"\
+"        *g_found = 1;\n"\
+"        return;\n"\
+"      }\n"\
+"    }\n"\
+"    if (pass_len + 2u < min_len) continue;\n"\
+"    for (uint j = 0; j < dict_length; ++j) {\n"\
+"      attempt[pass_len + 1u] = k_dict[j];\n"\
+"      if (*g_found) return;\n"\
+"      if (prkeccak_224_compare(k_hash, attempt, (int)(pass_len + 2u))) {\n"\
+"        for (uint k = 0; k < pass_len + 2u; ++k) result[k] = attempt[k];\n"\
+"        result[pass_len + 2u] = 0;\n"\
+"        *g_found = 1;\n"\
+"        return;\n"\
+"      }\n"\
 "    }\n"\
 "  }\n"\
 "}\n"\

--- a/src/opencl/kernels/keccak_256.cl
+++ b/src/opencl/kernels/keccak_256.cl
@@ -149,25 +149,27 @@ __kernel void prkeccak_256_kernel(__global uchar* result,
     attempt[pos] = k_dict[idx % dict_length];
     idx /= dict_length;
   }
-  if (pass_len >= min_len) {
-    if (*g_found) return;
-    if (prkeccak_256_compare(k_hash, attempt, (int)pass_len)) {
-      for (uint k = 0; k < pass_len; ++k) result[k] = attempt[k];
-      result[pass_len] = 0;
-      *g_found = 1;
-      return;
-    }
-  }
-  const uint attempt_len = pass_len + 1u;
-  if (attempt_len < min_len) return;
   for (uint i = 0; i < dict_length; ++i) {
     attempt[pass_len] = k_dict[i];
-    if (*g_found) return;
-    if (prkeccak_256_compare(k_hash, attempt, (int)attempt_len)) {
-      for (uint k = 0; k < attempt_len; ++k) result[k] = attempt[k];
-      result[attempt_len] = 0;
-      *g_found = 1;
-      return;
+    if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {
+      if (*g_found) return;
+      if (prkeccak_256_compare(k_hash, attempt, (int)(pass_len + 1u))) {
+        for (uint k = 0; k < pass_len + 1u; ++k) result[k] = attempt[k];
+        result[pass_len + 1u] = 0;
+        *g_found = 1;
+        return;
+      }
+    }
+    if (pass_len + 2u < min_len) continue;
+    for (uint j = 0; j < dict_length; ++j) {
+      attempt[pass_len + 1u] = k_dict[j];
+      if (*g_found) return;
+      if (prkeccak_256_compare(k_hash, attempt, (int)(pass_len + 2u))) {
+        for (uint k = 0; k < pass_len + 2u; ++k) result[k] = attempt[k];
+        result[pass_len + 2u] = 0;
+        *g_found = 1;
+        return;
+      }
     }
   }
 }

--- a/src/opencl/kernels/keccak_256.cl.h
+++ b/src/opencl/kernels/keccak_256.cl.h
@@ -149,25 +149,27 @@
 "    attempt[pos] = k_dict[idx % dict_length];\n"\
 "    idx /= dict_length;\n"\
 "  }\n"\
-"  if (pass_len >= min_len) {\n"\
-"    if (*g_found) return;\n"\
-"    if (prkeccak_256_compare(k_hash, attempt, (int)pass_len)) {\n"\
-"      for (uint k = 0; k < pass_len; ++k) result[k] = attempt[k];\n"\
-"      result[pass_len] = 0;\n"\
-"      *g_found = 1;\n"\
-"      return;\n"\
-"    }\n"\
-"  }\n"\
-"  const uint attempt_len = pass_len + 1u;\n"\
-"  if (attempt_len < min_len) return;\n"\
 "  for (uint i = 0; i < dict_length; ++i) {\n"\
 "    attempt[pass_len] = k_dict[i];\n"\
-"    if (*g_found) return;\n"\
-"    if (prkeccak_256_compare(k_hash, attempt, (int)attempt_len)) {\n"\
-"      for (uint k = 0; k < attempt_len; ++k) result[k] = attempt[k];\n"\
-"      result[attempt_len] = 0;\n"\
-"      *g_found = 1;\n"\
-"      return;\n"\
+"    if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {\n"\
+"      if (*g_found) return;\n"\
+"      if (prkeccak_256_compare(k_hash, attempt, (int)(pass_len + 1u))) {\n"\
+"        for (uint k = 0; k < pass_len + 1u; ++k) result[k] = attempt[k];\n"\
+"        result[pass_len + 1u] = 0;\n"\
+"        *g_found = 1;\n"\
+"        return;\n"\
+"      }\n"\
+"    }\n"\
+"    if (pass_len + 2u < min_len) continue;\n"\
+"    for (uint j = 0; j < dict_length; ++j) {\n"\
+"      attempt[pass_len + 1u] = k_dict[j];\n"\
+"      if (*g_found) return;\n"\
+"      if (prkeccak_256_compare(k_hash, attempt, (int)(pass_len + 2u))) {\n"\
+"        for (uint k = 0; k < pass_len + 2u; ++k) result[k] = attempt[k];\n"\
+"        result[pass_len + 2u] = 0;\n"\
+"        *g_found = 1;\n"\
+"        return;\n"\
+"      }\n"\
 "    }\n"\
 "  }\n"\
 "}\n"\

--- a/src/opencl/kernels/keccak_384.cl
+++ b/src/opencl/kernels/keccak_384.cl
@@ -149,25 +149,27 @@ __kernel void prkeccak_384_kernel(__global uchar* result,
     attempt[pos] = k_dict[idx % dict_length];
     idx /= dict_length;
   }
-  if (pass_len >= min_len) {
-    if (*g_found) return;
-    if (prkeccak_384_compare(k_hash, attempt, (int)pass_len)) {
-      for (uint k = 0; k < pass_len; ++k) result[k] = attempt[k];
-      result[pass_len] = 0;
-      *g_found = 1;
-      return;
-    }
-  }
-  const uint attempt_len = pass_len + 1u;
-  if (attempt_len < min_len) return;
   for (uint i = 0; i < dict_length; ++i) {
     attempt[pass_len] = k_dict[i];
-    if (*g_found) return;
-    if (prkeccak_384_compare(k_hash, attempt, (int)attempt_len)) {
-      for (uint k = 0; k < attempt_len; ++k) result[k] = attempt[k];
-      result[attempt_len] = 0;
-      *g_found = 1;
-      return;
+    if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {
+      if (*g_found) return;
+      if (prkeccak_384_compare(k_hash, attempt, (int)(pass_len + 1u))) {
+        for (uint k = 0; k < pass_len + 1u; ++k) result[k] = attempt[k];
+        result[pass_len + 1u] = 0;
+        *g_found = 1;
+        return;
+      }
+    }
+    if (pass_len + 2u < min_len) continue;
+    for (uint j = 0; j < dict_length; ++j) {
+      attempt[pass_len + 1u] = k_dict[j];
+      if (*g_found) return;
+      if (prkeccak_384_compare(k_hash, attempt, (int)(pass_len + 2u))) {
+        for (uint k = 0; k < pass_len + 2u; ++k) result[k] = attempt[k];
+        result[pass_len + 2u] = 0;
+        *g_found = 1;
+        return;
+      }
     }
   }
 }

--- a/src/opencl/kernels/keccak_384.cl.h
+++ b/src/opencl/kernels/keccak_384.cl.h
@@ -149,25 +149,27 @@
 "    attempt[pos] = k_dict[idx % dict_length];\n"\
 "    idx /= dict_length;\n"\
 "  }\n"\
-"  if (pass_len >= min_len) {\n"\
-"    if (*g_found) return;\n"\
-"    if (prkeccak_384_compare(k_hash, attempt, (int)pass_len)) {\n"\
-"      for (uint k = 0; k < pass_len; ++k) result[k] = attempt[k];\n"\
-"      result[pass_len] = 0;\n"\
-"      *g_found = 1;\n"\
-"      return;\n"\
-"    }\n"\
-"  }\n"\
-"  const uint attempt_len = pass_len + 1u;\n"\
-"  if (attempt_len < min_len) return;\n"\
 "  for (uint i = 0; i < dict_length; ++i) {\n"\
 "    attempt[pass_len] = k_dict[i];\n"\
-"    if (*g_found) return;\n"\
-"    if (prkeccak_384_compare(k_hash, attempt, (int)attempt_len)) {\n"\
-"      for (uint k = 0; k < attempt_len; ++k) result[k] = attempt[k];\n"\
-"      result[attempt_len] = 0;\n"\
-"      *g_found = 1;\n"\
-"      return;\n"\
+"    if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {\n"\
+"      if (*g_found) return;\n"\
+"      if (prkeccak_384_compare(k_hash, attempt, (int)(pass_len + 1u))) {\n"\
+"        for (uint k = 0; k < pass_len + 1u; ++k) result[k] = attempt[k];\n"\
+"        result[pass_len + 1u] = 0;\n"\
+"        *g_found = 1;\n"\
+"        return;\n"\
+"      }\n"\
+"    }\n"\
+"    if (pass_len + 2u < min_len) continue;\n"\
+"    for (uint j = 0; j < dict_length; ++j) {\n"\
+"      attempt[pass_len + 1u] = k_dict[j];\n"\
+"      if (*g_found) return;\n"\
+"      if (prkeccak_384_compare(k_hash, attempt, (int)(pass_len + 2u))) {\n"\
+"        for (uint k = 0; k < pass_len + 2u; ++k) result[k] = attempt[k];\n"\
+"        result[pass_len + 2u] = 0;\n"\
+"        *g_found = 1;\n"\
+"        return;\n"\
+"      }\n"\
 "    }\n"\
 "  }\n"\
 "}\n"\

--- a/src/opencl/kernels/keccak_512.cl
+++ b/src/opencl/kernels/keccak_512.cl
@@ -149,25 +149,27 @@ __kernel void prkeccak_512_kernel(__global uchar* result,
     attempt[pos] = k_dict[idx % dict_length];
     idx /= dict_length;
   }
-  if (pass_len >= min_len) {
-    if (*g_found) return;
-    if (prkeccak_512_compare(k_hash, attempt, (int)pass_len)) {
-      for (uint k = 0; k < pass_len; ++k) result[k] = attempt[k];
-      result[pass_len] = 0;
-      *g_found = 1;
-      return;
-    }
-  }
-  const uint attempt_len = pass_len + 1u;
-  if (attempt_len < min_len) return;
   for (uint i = 0; i < dict_length; ++i) {
     attempt[pass_len] = k_dict[i];
-    if (*g_found) return;
-    if (prkeccak_512_compare(k_hash, attempt, (int)attempt_len)) {
-      for (uint k = 0; k < attempt_len; ++k) result[k] = attempt[k];
-      result[attempt_len] = 0;
-      *g_found = 1;
-      return;
+    if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {
+      if (*g_found) return;
+      if (prkeccak_512_compare(k_hash, attempt, (int)(pass_len + 1u))) {
+        for (uint k = 0; k < pass_len + 1u; ++k) result[k] = attempt[k];
+        result[pass_len + 1u] = 0;
+        *g_found = 1;
+        return;
+      }
+    }
+    if (pass_len + 2u < min_len) continue;
+    for (uint j = 0; j < dict_length; ++j) {
+      attempt[pass_len + 1u] = k_dict[j];
+      if (*g_found) return;
+      if (prkeccak_512_compare(k_hash, attempt, (int)(pass_len + 2u))) {
+        for (uint k = 0; k < pass_len + 2u; ++k) result[k] = attempt[k];
+        result[pass_len + 2u] = 0;
+        *g_found = 1;
+        return;
+      }
     }
   }
 }

--- a/src/opencl/kernels/keccak_512.cl.h
+++ b/src/opencl/kernels/keccak_512.cl.h
@@ -149,25 +149,27 @@
 "    attempt[pos] = k_dict[idx % dict_length];\n"\
 "    idx /= dict_length;\n"\
 "  }\n"\
-"  if (pass_len >= min_len) {\n"\
-"    if (*g_found) return;\n"\
-"    if (prkeccak_512_compare(k_hash, attempt, (int)pass_len)) {\n"\
-"      for (uint k = 0; k < pass_len; ++k) result[k] = attempt[k];\n"\
-"      result[pass_len] = 0;\n"\
-"      *g_found = 1;\n"\
-"      return;\n"\
-"    }\n"\
-"  }\n"\
-"  const uint attempt_len = pass_len + 1u;\n"\
-"  if (attempt_len < min_len) return;\n"\
 "  for (uint i = 0; i < dict_length; ++i) {\n"\
 "    attempt[pass_len] = k_dict[i];\n"\
-"    if (*g_found) return;\n"\
-"    if (prkeccak_512_compare(k_hash, attempt, (int)attempt_len)) {\n"\
-"      for (uint k = 0; k < attempt_len; ++k) result[k] = attempt[k];\n"\
-"      result[attempt_len] = 0;\n"\
-"      *g_found = 1;\n"\
-"      return;\n"\
+"    if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {\n"\
+"      if (*g_found) return;\n"\
+"      if (prkeccak_512_compare(k_hash, attempt, (int)(pass_len + 1u))) {\n"\
+"        for (uint k = 0; k < pass_len + 1u; ++k) result[k] = attempt[k];\n"\
+"        result[pass_len + 1u] = 0;\n"\
+"        *g_found = 1;\n"\
+"        return;\n"\
+"      }\n"\
+"    }\n"\
+"    if (pass_len + 2u < min_len) continue;\n"\
+"    for (uint j = 0; j < dict_length; ++j) {\n"\
+"      attempt[pass_len + 1u] = k_dict[j];\n"\
+"      if (*g_found) return;\n"\
+"      if (prkeccak_512_compare(k_hash, attempt, (int)(pass_len + 2u))) {\n"\
+"        for (uint k = 0; k < pass_len + 2u; ++k) result[k] = attempt[k];\n"\
+"        result[pass_len + 2u] = 0;\n"\
+"        *g_found = 1;\n"\
+"        return;\n"\
+"      }\n"\
 "    }\n"\
 "  }\n"\
 "}\n"\

--- a/src/opencl/kernels/md2.cl
+++ b/src/opencl/kernels/md2.cl
@@ -92,25 +92,27 @@ __kernel void prmd2_kernel(__global uchar* result,
     attempt[pos] = k_dict[idx % dict_length];
     idx /= dict_length;
   }
-  if (pass_len >= min_len) {
-    if (*g_found) return;
-    if (prmd2_compare(k_hash, attempt, (int)pass_len)) {
-      for (uint k = 0; k < pass_len; ++k) result[k] = attempt[k];
-      result[pass_len] = 0;
-      *g_found = 1;
-      return;
-    }
-  }
-  const uint attempt_len = pass_len + 1u;
-  if (attempt_len < min_len) return;
   for (uint i = 0; i < dict_length; ++i) {
     attempt[pass_len] = k_dict[i];
-    if (*g_found) return;
-    if (prmd2_compare(k_hash, attempt, (int)attempt_len)) {
-      for (uint k = 0; k < attempt_len; ++k) result[k] = attempt[k];
-      result[attempt_len] = 0;
-      *g_found = 1;
-      return;
+    if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {
+      if (*g_found) return;
+      if (prmd2_compare(k_hash, attempt, (int)(pass_len + 1u))) {
+        for (uint k = 0; k < pass_len + 1u; ++k) result[k] = attempt[k];
+        result[pass_len + 1u] = 0;
+        *g_found = 1;
+        return;
+      }
+    }
+    if (pass_len + 2u < min_len) continue;
+    for (uint j = 0; j < dict_length; ++j) {
+      attempt[pass_len + 1u] = k_dict[j];
+      if (*g_found) return;
+      if (prmd2_compare(k_hash, attempt, (int)(pass_len + 2u))) {
+        for (uint k = 0; k < pass_len + 2u; ++k) result[k] = attempt[k];
+        result[pass_len + 2u] = 0;
+        *g_found = 1;
+        return;
+      }
     }
   }
 }

--- a/src/opencl/kernels/md2.cl.h
+++ b/src/opencl/kernels/md2.cl.h
@@ -92,25 +92,27 @@
 "    attempt[pos] = k_dict[idx % dict_length];\n"\
 "    idx /= dict_length;\n"\
 "  }\n"\
-"  if (pass_len >= min_len) {\n"\
-"    if (*g_found) return;\n"\
-"    if (prmd2_compare(k_hash, attempt, (int)pass_len)) {\n"\
-"      for (uint k = 0; k < pass_len; ++k) result[k] = attempt[k];\n"\
-"      result[pass_len] = 0;\n"\
-"      *g_found = 1;\n"\
-"      return;\n"\
-"    }\n"\
-"  }\n"\
-"  const uint attempt_len = pass_len + 1u;\n"\
-"  if (attempt_len < min_len) return;\n"\
 "  for (uint i = 0; i < dict_length; ++i) {\n"\
 "    attempt[pass_len] = k_dict[i];\n"\
-"    if (*g_found) return;\n"\
-"    if (prmd2_compare(k_hash, attempt, (int)attempt_len)) {\n"\
-"      for (uint k = 0; k < attempt_len; ++k) result[k] = attempt[k];\n"\
-"      result[attempt_len] = 0;\n"\
-"      *g_found = 1;\n"\
-"      return;\n"\
+"    if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {\n"\
+"      if (*g_found) return;\n"\
+"      if (prmd2_compare(k_hash, attempt, (int)(pass_len + 1u))) {\n"\
+"        for (uint k = 0; k < pass_len + 1u; ++k) result[k] = attempt[k];\n"\
+"        result[pass_len + 1u] = 0;\n"\
+"        *g_found = 1;\n"\
+"        return;\n"\
+"      }\n"\
+"    }\n"\
+"    if (pass_len + 2u < min_len) continue;\n"\
+"    for (uint j = 0; j < dict_length; ++j) {\n"\
+"      attempt[pass_len + 1u] = k_dict[j];\n"\
+"      if (*g_found) return;\n"\
+"      if (prmd2_compare(k_hash, attempt, (int)(pass_len + 2u))) {\n"\
+"        for (uint k = 0; k < pass_len + 2u; ++k) result[k] = attempt[k];\n"\
+"        result[pass_len + 2u] = 0;\n"\
+"        *g_found = 1;\n"\
+"        return;\n"\
+"      }\n"\
 "    }\n"\
 "  }\n"\
 "}\n"\

--- a/src/opencl/kernels/md4.cl
+++ b/src/opencl/kernels/md4.cl
@@ -6,7 +6,8 @@
 #define ROTL(x, n) (((x) << (n)) | ((x) >> (32 - (n))))
 #define T32(x) ((x) & 0xFFFFFFFFu)
 
-static int prmd4_compare(__global const uchar* k_hash, uchar* password, const int length) {
+/* length is the byte length of the buffer passed to MD4 (ASCII or UTF-16LE). */
+static int prmd4_compare(__global const uchar* k_hash, const uchar* password, const int length) {
   const uint ar = (uint)k_hash[0] | (uint)k_hash[1] << 8 | (uint)k_hash[2] << 16 | (uint)k_hash[3] << 24;
   const uint br = (uint)k_hash[4] | (uint)k_hash[5] << 8 | (uint)k_hash[6] << 16 | (uint)k_hash[7] << 24;
   const uint cr = (uint)k_hash[8] | (uint)k_hash[9] << 8 | (uint)k_hash[10] << 16 | (uint)k_hash[11] << 24;
@@ -80,11 +81,13 @@ __kernel void prmd4_kernel(__global uchar* result,
                           const uint count,
                           const uint pass_len,
                           const uint dict_length,
-                          const uint min_len) {
+                          const uint min_len,
+                          const uint use_wide_pass) {
   const uint ix = get_global_id(0);
   if (ix >= count || *g_found) return;
   ulong idx = start + (ulong)ix;
   uchar attempt[GPU_ATTEMPT_SIZE];
+  ushort wide_attempt[GPU_ATTEMPT_SIZE];
   for (int pos = (int)pass_len - 1; pos >= 0; --pos) {
     attempt[pos] = k_dict[idx % dict_length];
     idx /= dict_length;
@@ -93,9 +96,20 @@ __kernel void prmd4_kernel(__global uchar* result,
     attempt[pass_len] = k_dict[i];
     if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {
       if (*g_found) return;
-      if (prmd4_compare(k_hash, attempt, (int)(pass_len + 1u))) {
-        for (uint k = 0; k < pass_len + 1u; ++k) result[k] = attempt[k];
-        result[pass_len + 1u] = 0;
+      const uint cur_len = pass_len + 1u;
+      const uchar* cmp_buf;
+      int cmp_len;
+      if (use_wide_pass) {
+        for (uint k = 0; k < cur_len; ++k) wide_attempt[k] = (ushort)attempt[k];
+        cmp_buf = (const uchar*)wide_attempt;
+        cmp_len = (int)(cur_len * (uint)sizeof(ushort));
+      } else {
+        cmp_buf = attempt;
+        cmp_len = (int)cur_len;
+      }
+      if (prmd4_compare(k_hash, cmp_buf, cmp_len)) {
+        for (uint k = 0; k < cur_len; ++k) result[k] = attempt[k];
+        result[cur_len] = 0;
         *g_found = 1;
         return;
       }
@@ -104,9 +118,20 @@ __kernel void prmd4_kernel(__global uchar* result,
     for (uint j = 0; j < dict_length; ++j) {
       attempt[pass_len + 1u] = k_dict[j];
       if (*g_found) return;
-      if (prmd4_compare(k_hash, attempt, (int)(pass_len + 2u))) {
-        for (uint k = 0; k < pass_len + 2u; ++k) result[k] = attempt[k];
-        result[pass_len + 2u] = 0;
+      const uint cur_len = pass_len + 2u;
+      const uchar* cmp_buf;
+      int cmp_len;
+      if (use_wide_pass) {
+        for (uint k = 0; k < cur_len; ++k) wide_attempt[k] = (ushort)attempt[k];
+        cmp_buf = (const uchar*)wide_attempt;
+        cmp_len = (int)(cur_len * (uint)sizeof(ushort));
+      } else {
+        cmp_buf = attempt;
+        cmp_len = (int)cur_len;
+      }
+      if (prmd4_compare(k_hash, cmp_buf, cmp_len)) {
+        for (uint k = 0; k < cur_len; ++k) result[k] = attempt[k];
+        result[cur_len] = 0;
         *g_found = 1;
         return;
       }

--- a/src/opencl/kernels/md4.cl.h
+++ b/src/opencl/kernels/md4.cl.h
@@ -6,7 +6,8 @@
 "#define ROTL(x, n) (((x) << (n)) | ((x) >> (32 - (n))))\n"\
 "#define T32(x) ((x) & 0xFFFFFFFFu)\n"\
 "\n"\
-"static int prmd4_compare(__global const uchar* k_hash, uchar* password, const int length) {\n"\
+"/* length is the byte length of the buffer passed to MD4 (ASCII or UTF-16LE). */\n"\
+"static int prmd4_compare(__global const uchar* k_hash, const uchar* password, const int length) {\n"\
 "  const uint ar = (uint)k_hash[0] | (uint)k_hash[1] << 8 | (uint)k_hash[2] << 16 | (uint)k_hash[3] << 24;\n"\
 "  const uint br = (uint)k_hash[4] | (uint)k_hash[5] << 8 | (uint)k_hash[6] << 16 | (uint)k_hash[7] << 24;\n"\
 "  const uint cr = (uint)k_hash[8] | (uint)k_hash[9] << 8 | (uint)k_hash[10] << 16 | (uint)k_hash[11] << 24;\n"\
@@ -80,11 +81,13 @@
 "                          const uint count,\n"\
 "                          const uint pass_len,\n"\
 "                          const uint dict_length,\n"\
-"                          const uint min_len) {\n"\
+"                          const uint min_len,\n"\
+"                          const uint use_wide_pass) {\n"\
 "  const uint ix = get_global_id(0);\n"\
 "  if (ix >= count || *g_found) return;\n"\
 "  ulong idx = start + (ulong)ix;\n"\
 "  uchar attempt[GPU_ATTEMPT_SIZE];\n"\
+"  ushort wide_attempt[GPU_ATTEMPT_SIZE];\n"\
 "  for (int pos = (int)pass_len - 1; pos >= 0; --pos) {\n"\
 "    attempt[pos] = k_dict[idx % dict_length];\n"\
 "    idx /= dict_length;\n"\
@@ -93,9 +96,20 @@
 "    attempt[pass_len] = k_dict[i];\n"\
 "    if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {\n"\
 "      if (*g_found) return;\n"\
-"      if (prmd4_compare(k_hash, attempt, (int)(pass_len + 1u))) {\n"\
-"        for (uint k = 0; k < pass_len + 1u; ++k) result[k] = attempt[k];\n"\
-"        result[pass_len + 1u] = 0;\n"\
+"      const uint cur_len = pass_len + 1u;\n"\
+"      const uchar* cmp_buf;\n"\
+"      int cmp_len;\n"\
+"      if (use_wide_pass) {\n"\
+"        for (uint k = 0; k < cur_len; ++k) wide_attempt[k] = (ushort)attempt[k];\n"\
+"        cmp_buf = (const uchar*)wide_attempt;\n"\
+"        cmp_len = (int)(cur_len * (uint)sizeof(ushort));\n"\
+"      } else {\n"\
+"        cmp_buf = attempt;\n"\
+"        cmp_len = (int)cur_len;\n"\
+"      }\n"\
+"      if (prmd4_compare(k_hash, cmp_buf, cmp_len)) {\n"\
+"        for (uint k = 0; k < cur_len; ++k) result[k] = attempt[k];\n"\
+"        result[cur_len] = 0;\n"\
 "        *g_found = 1;\n"\
 "        return;\n"\
 "      }\n"\
@@ -104,9 +118,20 @@
 "    for (uint j = 0; j < dict_length; ++j) {\n"\
 "      attempt[pass_len + 1u] = k_dict[j];\n"\
 "      if (*g_found) return;\n"\
-"      if (prmd4_compare(k_hash, attempt, (int)(pass_len + 2u))) {\n"\
-"        for (uint k = 0; k < pass_len + 2u; ++k) result[k] = attempt[k];\n"\
-"        result[pass_len + 2u] = 0;\n"\
+"      const uint cur_len = pass_len + 2u;\n"\
+"      const uchar* cmp_buf;\n"\
+"      int cmp_len;\n"\
+"      if (use_wide_pass) {\n"\
+"        for (uint k = 0; k < cur_len; ++k) wide_attempt[k] = (ushort)attempt[k];\n"\
+"        cmp_buf = (const uchar*)wide_attempt;\n"\
+"        cmp_len = (int)(cur_len * (uint)sizeof(ushort));\n"\
+"      } else {\n"\
+"        cmp_buf = attempt;\n"\
+"        cmp_len = (int)cur_len;\n"\
+"      }\n"\
+"      if (prmd4_compare(k_hash, cmp_buf, cmp_len)) {\n"\
+"        for (uint k = 0; k < cur_len; ++k) result[k] = attempt[k];\n"\
+"        result[cur_len] = 0;\n"\
 "        *g_found = 1;\n"\
 "        return;\n"\
 "      }\n"\

--- a/src/opencl/kernels/rmd128.cl
+++ b/src/opencl/kernels/rmd128.cl
@@ -233,25 +233,27 @@ __kernel void prrmd128_kernel(__global uchar* result,
     attempt[pos] = k_dict[idx % dict_length];
     idx /= dict_length;
   }
-  if (pass_len >= min_len) {
-    if (*g_found) return;
-    if (prrmd128_compare(k_hash, attempt, (int)pass_len)) {
-      for (uint k = 0; k < pass_len; ++k) result[k] = attempt[k];
-      result[pass_len] = 0;
-      *g_found = 1;
-      return;
-    }
-  }
-  const uint attempt_len = pass_len + 1u;
-  if (attempt_len < min_len) return;
   for (uint i = 0; i < dict_length; ++i) {
     attempt[pass_len] = k_dict[i];
-    if (*g_found) return;
-    if (prrmd128_compare(k_hash, attempt, (int)attempt_len)) {
-      for (uint k = 0; k < attempt_len; ++k) result[k] = attempt[k];
-      result[attempt_len] = 0;
-      *g_found = 1;
-      return;
+    if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {
+      if (*g_found) return;
+      if (prrmd128_compare(k_hash, attempt, (int)(pass_len + 1u))) {
+        for (uint k = 0; k < pass_len + 1u; ++k) result[k] = attempt[k];
+        result[pass_len + 1u] = 0;
+        *g_found = 1;
+        return;
+      }
+    }
+    if (pass_len + 2u < min_len) continue;
+    for (uint j = 0; j < dict_length; ++j) {
+      attempt[pass_len + 1u] = k_dict[j];
+      if (*g_found) return;
+      if (prrmd128_compare(k_hash, attempt, (int)(pass_len + 2u))) {
+        for (uint k = 0; k < pass_len + 2u; ++k) result[k] = attempt[k];
+        result[pass_len + 2u] = 0;
+        *g_found = 1;
+        return;
+      }
     }
   }
 }

--- a/src/opencl/kernels/rmd128.cl.h
+++ b/src/opencl/kernels/rmd128.cl.h
@@ -233,25 +233,27 @@
 "    attempt[pos] = k_dict[idx % dict_length];\n"\
 "    idx /= dict_length;\n"\
 "  }\n"\
-"  if (pass_len >= min_len) {\n"\
-"    if (*g_found) return;\n"\
-"    if (prrmd128_compare(k_hash, attempt, (int)pass_len)) {\n"\
-"      for (uint k = 0; k < pass_len; ++k) result[k] = attempt[k];\n"\
-"      result[pass_len] = 0;\n"\
-"      *g_found = 1;\n"\
-"      return;\n"\
-"    }\n"\
-"  }\n"\
-"  const uint attempt_len = pass_len + 1u;\n"\
-"  if (attempt_len < min_len) return;\n"\
 "  for (uint i = 0; i < dict_length; ++i) {\n"\
 "    attempt[pass_len] = k_dict[i];\n"\
-"    if (*g_found) return;\n"\
-"    if (prrmd128_compare(k_hash, attempt, (int)attempt_len)) {\n"\
-"      for (uint k = 0; k < attempt_len; ++k) result[k] = attempt[k];\n"\
-"      result[attempt_len] = 0;\n"\
-"      *g_found = 1;\n"\
-"      return;\n"\
+"    if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {\n"\
+"      if (*g_found) return;\n"\
+"      if (prrmd128_compare(k_hash, attempt, (int)(pass_len + 1u))) {\n"\
+"        for (uint k = 0; k < pass_len + 1u; ++k) result[k] = attempt[k];\n"\
+"        result[pass_len + 1u] = 0;\n"\
+"        *g_found = 1;\n"\
+"        return;\n"\
+"      }\n"\
+"    }\n"\
+"    if (pass_len + 2u < min_len) continue;\n"\
+"    for (uint j = 0; j < dict_length; ++j) {\n"\
+"      attempt[pass_len + 1u] = k_dict[j];\n"\
+"      if (*g_found) return;\n"\
+"      if (prrmd128_compare(k_hash, attempt, (int)(pass_len + 2u))) {\n"\
+"        for (uint k = 0; k < pass_len + 2u; ++k) result[k] = attempt[k];\n"\
+"        result[pass_len + 2u] = 0;\n"\
+"        *g_found = 1;\n"\
+"        return;\n"\
+"      }\n"\
 "    }\n"\
 "  }\n"\
-"}\n"
+"}\n"\

--- a/src/opencl/kernels/rmd160.cl
+++ b/src/opencl/kernels/rmd160.cl
@@ -140,25 +140,27 @@ __kernel void prrmd160_kernel(__global uchar* result,
     attempt[pos] = k_dict[idx % dict_length];
     idx /= dict_length;
   }
-  if (pass_len >= min_len) {
-    if (*g_found) return;
-    if (prrmd160_compare(k_hash, attempt, (int)pass_len)) {
-      for (uint k = 0; k < pass_len; ++k) result[k] = attempt[k];
-      result[pass_len] = 0;
-      *g_found = 1;
-      return;
-    }
-  }
-  const uint attempt_len = pass_len + 1u;
-  if (attempt_len < min_len) return;
   for (uint i = 0; i < dict_length; ++i) {
     attempt[pass_len] = k_dict[i];
-    if (*g_found) return;
-    if (prrmd160_compare(k_hash, attempt, (int)attempt_len)) {
-      for (uint k = 0; k < attempt_len; ++k) result[k] = attempt[k];
-      result[attempt_len] = 0;
-      *g_found = 1;
-      return;
+    if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {
+      if (*g_found) return;
+      if (prrmd160_compare(k_hash, attempt, (int)(pass_len + 1u))) {
+        for (uint k = 0; k < pass_len + 1u; ++k) result[k] = attempt[k];
+        result[pass_len + 1u] = 0;
+        *g_found = 1;
+        return;
+      }
+    }
+    if (pass_len + 2u < min_len) continue;
+    for (uint j = 0; j < dict_length; ++j) {
+      attempt[pass_len + 1u] = k_dict[j];
+      if (*g_found) return;
+      if (prrmd160_compare(k_hash, attempt, (int)(pass_len + 2u))) {
+        for (uint k = 0; k < pass_len + 2u; ++k) result[k] = attempt[k];
+        result[pass_len + 2u] = 0;
+        *g_found = 1;
+        return;
+      }
     }
   }
 }

--- a/src/opencl/kernels/rmd160.cl.h
+++ b/src/opencl/kernels/rmd160.cl.h
@@ -140,25 +140,27 @@
 "    attempt[pos] = k_dict[idx % dict_length];\n"\
 "    idx /= dict_length;\n"\
 "  }\n"\
-"  if (pass_len >= min_len) {\n"\
-"    if (*g_found) return;\n"\
-"    if (prrmd160_compare(k_hash, attempt, (int)pass_len)) {\n"\
-"      for (uint k = 0; k < pass_len; ++k) result[k] = attempt[k];\n"\
-"      result[pass_len] = 0;\n"\
-"      *g_found = 1;\n"\
-"      return;\n"\
-"    }\n"\
-"  }\n"\
-"  const uint attempt_len = pass_len + 1u;\n"\
-"  if (attempt_len < min_len) return;\n"\
 "  for (uint i = 0; i < dict_length; ++i) {\n"\
 "    attempt[pass_len] = k_dict[i];\n"\
-"    if (*g_found) return;\n"\
-"    if (prrmd160_compare(k_hash, attempt, (int)attempt_len)) {\n"\
-"      for (uint k = 0; k < attempt_len; ++k) result[k] = attempt[k];\n"\
-"      result[attempt_len] = 0;\n"\
-"      *g_found = 1;\n"\
-"      return;\n"\
+"    if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {\n"\
+"      if (*g_found) return;\n"\
+"      if (prrmd160_compare(k_hash, attempt, (int)(pass_len + 1u))) {\n"\
+"        for (uint k = 0; k < pass_len + 1u; ++k) result[k] = attempt[k];\n"\
+"        result[pass_len + 1u] = 0;\n"\
+"        *g_found = 1;\n"\
+"        return;\n"\
+"      }\n"\
+"    }\n"\
+"    if (pass_len + 2u < min_len) continue;\n"\
+"    for (uint j = 0; j < dict_length; ++j) {\n"\
+"      attempt[pass_len + 1u] = k_dict[j];\n"\
+"      if (*g_found) return;\n"\
+"      if (prrmd160_compare(k_hash, attempt, (int)(pass_len + 2u))) {\n"\
+"        for (uint k = 0; k < pass_len + 2u; ++k) result[k] = attempt[k];\n"\
+"        result[pass_len + 2u] = 0;\n"\
+"        *g_found = 1;\n"\
+"        return;\n"\
+"      }\n"\
 "    }\n"\
 "  }\n"\
 "}\n"\

--- a/src/opencl/kernels/rmd256.cl
+++ b/src/opencl/kernels/rmd256.cl
@@ -235,25 +235,27 @@ __kernel void prrmd256_kernel(__global uchar* result,
     attempt[pos] = k_dict[idx % dict_length];
     idx /= dict_length;
   }
-  if (pass_len >= min_len) {
-    if (*g_found) return;
-    if (prrmd256_compare(k_hash, attempt, (int)pass_len)) {
-      for (uint k = 0; k < pass_len; ++k) result[k] = attempt[k];
-      result[pass_len] = 0;
-      *g_found = 1;
-      return;
-    }
-  }
-  const uint attempt_len = pass_len + 1u;
-  if (attempt_len < min_len) return;
   for (uint i = 0; i < dict_length; ++i) {
     attempt[pass_len] = k_dict[i];
-    if (*g_found) return;
-    if (prrmd256_compare(k_hash, attempt, (int)attempt_len)) {
-      for (uint k = 0; k < attempt_len; ++k) result[k] = attempt[k];
-      result[attempt_len] = 0;
-      *g_found = 1;
-      return;
+    if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {
+      if (*g_found) return;
+      if (prrmd256_compare(k_hash, attempt, (int)(pass_len + 1u))) {
+        for (uint k = 0; k < pass_len + 1u; ++k) result[k] = attempt[k];
+        result[pass_len + 1u] = 0;
+        *g_found = 1;
+        return;
+      }
+    }
+    if (pass_len + 2u < min_len) continue;
+    for (uint j = 0; j < dict_length; ++j) {
+      attempt[pass_len + 1u] = k_dict[j];
+      if (*g_found) return;
+      if (prrmd256_compare(k_hash, attempt, (int)(pass_len + 2u))) {
+        for (uint k = 0; k < pass_len + 2u; ++k) result[k] = attempt[k];
+        result[pass_len + 2u] = 0;
+        *g_found = 1;
+        return;
+      }
     }
   }
 }

--- a/src/opencl/kernels/rmd256.cl.h
+++ b/src/opencl/kernels/rmd256.cl.h
@@ -235,25 +235,27 @@
 "    attempt[pos] = k_dict[idx % dict_length];\n"\
 "    idx /= dict_length;\n"\
 "  }\n"\
-"  if (pass_len >= min_len) {\n"\
-"    if (*g_found) return;\n"\
-"    if (prrmd256_compare(k_hash, attempt, (int)pass_len)) {\n"\
-"      for (uint k = 0; k < pass_len; ++k) result[k] = attempt[k];\n"\
-"      result[pass_len] = 0;\n"\
-"      *g_found = 1;\n"\
-"      return;\n"\
-"    }\n"\
-"  }\n"\
-"  const uint attempt_len = pass_len + 1u;\n"\
-"  if (attempt_len < min_len) return;\n"\
 "  for (uint i = 0; i < dict_length; ++i) {\n"\
 "    attempt[pass_len] = k_dict[i];\n"\
-"    if (*g_found) return;\n"\
-"    if (prrmd256_compare(k_hash, attempt, (int)attempt_len)) {\n"\
-"      for (uint k = 0; k < attempt_len; ++k) result[k] = attempt[k];\n"\
-"      result[attempt_len] = 0;\n"\
-"      *g_found = 1;\n"\
-"      return;\n"\
+"    if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {\n"\
+"      if (*g_found) return;\n"\
+"      if (prrmd256_compare(k_hash, attempt, (int)(pass_len + 1u))) {\n"\
+"        for (uint k = 0; k < pass_len + 1u; ++k) result[k] = attempt[k];\n"\
+"        result[pass_len + 1u] = 0;\n"\
+"        *g_found = 1;\n"\
+"        return;\n"\
+"      }\n"\
+"    }\n"\
+"    if (pass_len + 2u < min_len) continue;\n"\
+"    for (uint j = 0; j < dict_length; ++j) {\n"\
+"      attempt[pass_len + 1u] = k_dict[j];\n"\
+"      if (*g_found) return;\n"\
+"      if (prrmd256_compare(k_hash, attempt, (int)(pass_len + 2u))) {\n"\
+"        for (uint k = 0; k < pass_len + 2u; ++k) result[k] = attempt[k];\n"\
+"        result[pass_len + 2u] = 0;\n"\
+"        *g_found = 1;\n"\
+"        return;\n"\
+"      }\n"\
 "    }\n"\
 "  }\n"\
-"}\n"
+"}\n"\

--- a/src/opencl/kernels/rmd320.cl
+++ b/src/opencl/kernels/rmd320.cl
@@ -275,25 +275,27 @@ __kernel void prrmd320_kernel(__global uchar* result,
     attempt[pos] = k_dict[idx % dict_length];
     idx /= dict_length;
   }
-  if (pass_len >= min_len) {
-    if (*g_found) return;
-    if (prrmd320_compare(k_hash, attempt, (int)pass_len)) {
-      for (uint k = 0; k < pass_len; ++k) result[k] = attempt[k];
-      result[pass_len] = 0;
-      *g_found = 1;
-      return;
-    }
-  }
-  const uint attempt_len = pass_len + 1u;
-  if (attempt_len < min_len) return;
   for (uint i = 0; i < dict_length; ++i) {
     attempt[pass_len] = k_dict[i];
-    if (*g_found) return;
-    if (prrmd320_compare(k_hash, attempt, (int)attempt_len)) {
-      for (uint k = 0; k < attempt_len; ++k) result[k] = attempt[k];
-      result[attempt_len] = 0;
-      *g_found = 1;
-      return;
+    if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {
+      if (*g_found) return;
+      if (prrmd320_compare(k_hash, attempt, (int)(pass_len + 1u))) {
+        for (uint k = 0; k < pass_len + 1u; ++k) result[k] = attempt[k];
+        result[pass_len + 1u] = 0;
+        *g_found = 1;
+        return;
+      }
+    }
+    if (pass_len + 2u < min_len) continue;
+    for (uint j = 0; j < dict_length; ++j) {
+      attempt[pass_len + 1u] = k_dict[j];
+      if (*g_found) return;
+      if (prrmd320_compare(k_hash, attempt, (int)(pass_len + 2u))) {
+        for (uint k = 0; k < pass_len + 2u; ++k) result[k] = attempt[k];
+        result[pass_len + 2u] = 0;
+        *g_found = 1;
+        return;
+      }
     }
   }
 }

--- a/src/opencl/kernels/rmd320.cl.h
+++ b/src/opencl/kernels/rmd320.cl.h
@@ -275,25 +275,27 @@
 "    attempt[pos] = k_dict[idx % dict_length];\n"\
 "    idx /= dict_length;\n"\
 "  }\n"\
-"  if (pass_len >= min_len) {\n"\
-"    if (*g_found) return;\n"\
-"    if (prrmd320_compare(k_hash, attempt, (int)pass_len)) {\n"\
-"      for (uint k = 0; k < pass_len; ++k) result[k] = attempt[k];\n"\
-"      result[pass_len] = 0;\n"\
-"      *g_found = 1;\n"\
-"      return;\n"\
-"    }\n"\
-"  }\n"\
-"  const uint attempt_len = pass_len + 1u;\n"\
-"  if (attempt_len < min_len) return;\n"\
 "  for (uint i = 0; i < dict_length; ++i) {\n"\
 "    attempt[pass_len] = k_dict[i];\n"\
-"    if (*g_found) return;\n"\
-"    if (prrmd320_compare(k_hash, attempt, (int)attempt_len)) {\n"\
-"      for (uint k = 0; k < attempt_len; ++k) result[k] = attempt[k];\n"\
-"      result[attempt_len] = 0;\n"\
-"      *g_found = 1;\n"\
-"      return;\n"\
+"    if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {\n"\
+"      if (*g_found) return;\n"\
+"      if (prrmd320_compare(k_hash, attempt, (int)(pass_len + 1u))) {\n"\
+"        for (uint k = 0; k < pass_len + 1u; ++k) result[k] = attempt[k];\n"\
+"        result[pass_len + 1u] = 0;\n"\
+"        *g_found = 1;\n"\
+"        return;\n"\
+"      }\n"\
+"    }\n"\
+"    if (pass_len + 2u < min_len) continue;\n"\
+"    for (uint j = 0; j < dict_length; ++j) {\n"\
+"      attempt[pass_len + 1u] = k_dict[j];\n"\
+"      if (*g_found) return;\n"\
+"      if (prrmd320_compare(k_hash, attempt, (int)(pass_len + 2u))) {\n"\
+"        for (uint k = 0; k < pass_len + 2u; ++k) result[k] = attempt[k];\n"\
+"        result[pass_len + 2u] = 0;\n"\
+"        *g_found = 1;\n"\
+"        return;\n"\
+"      }\n"\
 "    }\n"\
 "  }\n"\
-"}\n"
+"}\n"\

--- a/src/opencl/kernels/sha224.cl
+++ b/src/opencl/kernels/sha224.cl
@@ -234,25 +234,27 @@ __kernel void prsha224_kernel(__global uchar* result,
     attempt[pos] = k_dict[idx % dict_length];
     idx /= dict_length;
   }
-  if (pass_len >= min_len) {
-    if (*g_found) return;
-    if (prsha224_compare(k_hash, attempt, (int)pass_len)) {
-      for (uint k = 0; k < pass_len; ++k) result[k] = attempt[k];
-      result[pass_len] = 0;
-      *g_found = 1;
-      return;
-    }
-  }
-  const uint attempt_len = pass_len + 1u;
-  if (attempt_len < min_len) return;
   for (uint i = 0; i < dict_length; ++i) {
     attempt[pass_len] = k_dict[i];
-    if (*g_found) return;
-    if (prsha224_compare(k_hash, attempt, (int)attempt_len)) {
-      for (uint k = 0; k < attempt_len; ++k) result[k] = attempt[k];
-      result[attempt_len] = 0;
-      *g_found = 1;
-      return;
+    if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {
+      if (*g_found) return;
+      if (prsha224_compare(k_hash, attempt, (int)(pass_len + 1u))) {
+        for (uint k = 0; k < pass_len + 1u; ++k) result[k] = attempt[k];
+        result[pass_len + 1u] = 0;
+        *g_found = 1;
+        return;
+      }
+    }
+    if (pass_len + 2u < min_len) continue;
+    for (uint j = 0; j < dict_length; ++j) {
+      attempt[pass_len + 1u] = k_dict[j];
+      if (*g_found) return;
+      if (prsha224_compare(k_hash, attempt, (int)(pass_len + 2u))) {
+        for (uint k = 0; k < pass_len + 2u; ++k) result[k] = attempt[k];
+        result[pass_len + 2u] = 0;
+        *g_found = 1;
+        return;
+      }
     }
   }
 }

--- a/src/opencl/kernels/sha224.cl.h
+++ b/src/opencl/kernels/sha224.cl.h
@@ -234,26 +234,28 @@
 "    attempt[pos] = k_dict[idx % dict_length];\n"\
 "    idx /= dict_length;\n"\
 "  }\n"\
-"  if (pass_len >= min_len) {\n"\
-"    if (*g_found) return;\n"\
-"    if (prsha224_compare(k_hash, attempt, (int)pass_len)) {\n"\
-"      for (uint k = 0; k < pass_len; ++k) result[k] = attempt[k];\n"\
-"      result[pass_len] = 0;\n"\
-"      *g_found = 1;\n"\
-"      return;\n"\
-"    }\n"\
-"  }\n"\
-"  const uint attempt_len = pass_len + 1u;\n"\
-"  if (attempt_len < min_len) return;\n"\
 "  for (uint i = 0; i < dict_length; ++i) {\n"\
 "    attempt[pass_len] = k_dict[i];\n"\
-"    if (*g_found) return;\n"\
-"    if (prsha224_compare(k_hash, attempt, (int)attempt_len)) {\n"\
-"      for (uint k = 0; k < attempt_len; ++k) result[k] = attempt[k];\n"\
-"      result[attempt_len] = 0;\n"\
-"      *g_found = 1;\n"\
-"      return;\n"\
+"    if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {\n"\
+"      if (*g_found) return;\n"\
+"      if (prsha224_compare(k_hash, attempt, (int)(pass_len + 1u))) {\n"\
+"        for (uint k = 0; k < pass_len + 1u; ++k) result[k] = attempt[k];\n"\
+"        result[pass_len + 1u] = 0;\n"\
+"        *g_found = 1;\n"\
+"        return;\n"\
+"      }\n"\
+"    }\n"\
+"    if (pass_len + 2u < min_len) continue;\n"\
+"    for (uint j = 0; j < dict_length; ++j) {\n"\
+"      attempt[pass_len + 1u] = k_dict[j];\n"\
+"      if (*g_found) return;\n"\
+"      if (prsha224_compare(k_hash, attempt, (int)(pass_len + 2u))) {\n"\
+"        for (uint k = 0; k < pass_len + 2u; ++k) result[k] = attempt[k];\n"\
+"        result[pass_len + 2u] = 0;\n"\
+"        *g_found = 1;\n"\
+"        return;\n"\
+"      }\n"\
 "    }\n"\
 "  }\n"\
 "}\n"\
-"\n"
+"\n"\

--- a/src/opencl/kernels/sha256.cl
+++ b/src/opencl/kernels/sha256.cl
@@ -231,25 +231,27 @@ __kernel void prsha256_kernel(__global uchar* result,
     attempt[pos] = k_dict[idx % dict_length];
     idx /= dict_length;
   }
-  if (pass_len >= min_len) {
-    if (*g_found) return;
-    if (prsha256_compare(k_hash, attempt, (int)pass_len)) {
-      for (uint k = 0; k < pass_len; ++k) result[k] = attempt[k];
-      result[pass_len] = 0;
-      *g_found = 1;
-      return;
-    }
-  }
-  const uint attempt_len = pass_len + 1u;
-  if (attempt_len < min_len) return;
   for (uint i = 0; i < dict_length; ++i) {
     attempt[pass_len] = k_dict[i];
-    if (*g_found) return;
-    if (prsha256_compare(k_hash, attempt, (int)attempt_len)) {
-      for (uint k = 0; k < attempt_len; ++k) result[k] = attempt[k];
-      result[attempt_len] = 0;
-      *g_found = 1;
-      return;
+    if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {
+      if (*g_found) return;
+      if (prsha256_compare(k_hash, attempt, (int)(pass_len + 1u))) {
+        for (uint k = 0; k < pass_len + 1u; ++k) result[k] = attempt[k];
+        result[pass_len + 1u] = 0;
+        *g_found = 1;
+        return;
+      }
+    }
+    if (pass_len + 2u < min_len) continue;
+    for (uint j = 0; j < dict_length; ++j) {
+      attempt[pass_len + 1u] = k_dict[j];
+      if (*g_found) return;
+      if (prsha256_compare(k_hash, attempt, (int)(pass_len + 2u))) {
+        for (uint k = 0; k < pass_len + 2u; ++k) result[k] = attempt[k];
+        result[pass_len + 2u] = 0;
+        *g_found = 1;
+        return;
+      }
     }
   }
 }

--- a/src/opencl/kernels/sha256.cl.h
+++ b/src/opencl/kernels/sha256.cl.h
@@ -231,26 +231,28 @@
 "    attempt[pos] = k_dict[idx % dict_length];\n"\
 "    idx /= dict_length;\n"\
 "  }\n"\
-"  if (pass_len >= min_len) {\n"\
-"    if (*g_found) return;\n"\
-"    if (prsha256_compare(k_hash, attempt, (int)pass_len)) {\n"\
-"      for (uint k = 0; k < pass_len; ++k) result[k] = attempt[k];\n"\
-"      result[pass_len] = 0;\n"\
-"      *g_found = 1;\n"\
-"      return;\n"\
-"    }\n"\
-"  }\n"\
-"  const uint attempt_len = pass_len + 1u;\n"\
-"  if (attempt_len < min_len) return;\n"\
 "  for (uint i = 0; i < dict_length; ++i) {\n"\
 "    attempt[pass_len] = k_dict[i];\n"\
-"    if (*g_found) return;\n"\
-"    if (prsha256_compare(k_hash, attempt, (int)attempt_len)) {\n"\
-"      for (uint k = 0; k < attempt_len; ++k) result[k] = attempt[k];\n"\
-"      result[attempt_len] = 0;\n"\
-"      *g_found = 1;\n"\
-"      return;\n"\
+"    if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {\n"\
+"      if (*g_found) return;\n"\
+"      if (prsha256_compare(k_hash, attempt, (int)(pass_len + 1u))) {\n"\
+"        for (uint k = 0; k < pass_len + 1u; ++k) result[k] = attempt[k];\n"\
+"        result[pass_len + 1u] = 0;\n"\
+"        *g_found = 1;\n"\
+"        return;\n"\
+"      }\n"\
+"    }\n"\
+"    if (pass_len + 2u < min_len) continue;\n"\
+"    for (uint j = 0; j < dict_length; ++j) {\n"\
+"      attempt[pass_len + 1u] = k_dict[j];\n"\
+"      if (*g_found) return;\n"\
+"      if (prsha256_compare(k_hash, attempt, (int)(pass_len + 2u))) {\n"\
+"        for (uint k = 0; k < pass_len + 2u; ++k) result[k] = attempt[k];\n"\
+"        result[pass_len + 2u] = 0;\n"\
+"        *g_found = 1;\n"\
+"        return;\n"\
+"      }\n"\
 "    }\n"\
 "  }\n"\
 "}\n"\
-"\n"
+"\n"\

--- a/src/opencl/kernels/sha384.cl
+++ b/src/opencl/kernels/sha384.cl
@@ -277,25 +277,27 @@ __kernel void prsha384_kernel(__global uchar* result,
     attempt[pos] = k_dict[idx % dict_length];
     idx /= dict_length;
   }
-  if (pass_len >= min_len) {
-    if (*g_found) return;
-    if (prsha384_compare(k_hash, attempt, (int)pass_len)) {
-      for (uint k = 0; k < pass_len; ++k) result[k] = attempt[k];
-      result[pass_len] = 0;
-      *g_found = 1;
-      return;
-    }
-  }
-  const uint attempt_len = pass_len + 1u;
-  if (attempt_len < min_len) return;
   for (uint i = 0; i < dict_length; ++i) {
     attempt[pass_len] = k_dict[i];
-    if (*g_found) return;
-    if (prsha384_compare(k_hash, attempt, (int)attempt_len)) {
-      for (uint k = 0; k < attempt_len; ++k) result[k] = attempt[k];
-      result[attempt_len] = 0;
-      *g_found = 1;
-      return;
+    if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {
+      if (*g_found) return;
+      if (prsha384_compare(k_hash, attempt, (int)(pass_len + 1u))) {
+        for (uint k = 0; k < pass_len + 1u; ++k) result[k] = attempt[k];
+        result[pass_len + 1u] = 0;
+        *g_found = 1;
+        return;
+      }
+    }
+    if (pass_len + 2u < min_len) continue;
+    for (uint j = 0; j < dict_length; ++j) {
+      attempt[pass_len + 1u] = k_dict[j];
+      if (*g_found) return;
+      if (prsha384_compare(k_hash, attempt, (int)(pass_len + 2u))) {
+        for (uint k = 0; k < pass_len + 2u; ++k) result[k] = attempt[k];
+        result[pass_len + 2u] = 0;
+        *g_found = 1;
+        return;
+      }
     }
   }
 }

--- a/src/opencl/kernels/sha384.cl.h
+++ b/src/opencl/kernels/sha384.cl.h
@@ -277,25 +277,27 @@
 "    attempt[pos] = k_dict[idx % dict_length];\n"\
 "    idx /= dict_length;\n"\
 "  }\n"\
-"  if (pass_len >= min_len) {\n"\
-"    if (*g_found) return;\n"\
-"    if (prsha384_compare(k_hash, attempt, (int)pass_len)) {\n"\
-"      for (uint k = 0; k < pass_len; ++k) result[k] = attempt[k];\n"\
-"      result[pass_len] = 0;\n"\
-"      *g_found = 1;\n"\
-"      return;\n"\
-"    }\n"\
-"  }\n"\
-"  const uint attempt_len = pass_len + 1u;\n"\
-"  if (attempt_len < min_len) return;\n"\
 "  for (uint i = 0; i < dict_length; ++i) {\n"\
 "    attempt[pass_len] = k_dict[i];\n"\
-"    if (*g_found) return;\n"\
-"    if (prsha384_compare(k_hash, attempt, (int)attempt_len)) {\n"\
-"      for (uint k = 0; k < attempt_len; ++k) result[k] = attempt[k];\n"\
-"      result[attempt_len] = 0;\n"\
-"      *g_found = 1;\n"\
-"      return;\n"\
+"    if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {\n"\
+"      if (*g_found) return;\n"\
+"      if (prsha384_compare(k_hash, attempt, (int)(pass_len + 1u))) {\n"\
+"        for (uint k = 0; k < pass_len + 1u; ++k) result[k] = attempt[k];\n"\
+"        result[pass_len + 1u] = 0;\n"\
+"        *g_found = 1;\n"\
+"        return;\n"\
+"      }\n"\
+"    }\n"\
+"    if (pass_len + 2u < min_len) continue;\n"\
+"    for (uint j = 0; j < dict_length; ++j) {\n"\
+"      attempt[pass_len + 1u] = k_dict[j];\n"\
+"      if (*g_found) return;\n"\
+"      if (prsha384_compare(k_hash, attempt, (int)(pass_len + 2u))) {\n"\
+"        for (uint k = 0; k < pass_len + 2u; ++k) result[k] = attempt[k];\n"\
+"        result[pass_len + 2u] = 0;\n"\
+"        *g_found = 1;\n"\
+"        return;\n"\
+"      }\n"\
 "    }\n"\
 "  }\n"\
 "}\n"\

--- a/src/opencl/kernels/sha3_224.cl
+++ b/src/opencl/kernels/sha3_224.cl
@@ -149,25 +149,27 @@ __kernel void prsha3_224_kernel(__global uchar* result,
     attempt[pos] = k_dict[idx % dict_length];
     idx /= dict_length;
   }
-  if (pass_len >= min_len) {
-    if (*g_found) return;
-    if (prsha3_224_compare(k_hash, attempt, (int)pass_len)) {
-      for (uint k = 0; k < pass_len; ++k) result[k] = attempt[k];
-      result[pass_len] = 0;
-      *g_found = 1;
-      return;
-    }
-  }
-  const uint attempt_len = pass_len + 1u;
-  if (attempt_len < min_len) return;
   for (uint i = 0; i < dict_length; ++i) {
     attempt[pass_len] = k_dict[i];
-    if (*g_found) return;
-    if (prsha3_224_compare(k_hash, attempt, (int)attempt_len)) {
-      for (uint k = 0; k < attempt_len; ++k) result[k] = attempt[k];
-      result[attempt_len] = 0;
-      *g_found = 1;
-      return;
+    if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {
+      if (*g_found) return;
+      if (prsha3_224_compare(k_hash, attempt, (int)(pass_len + 1u))) {
+        for (uint k = 0; k < pass_len + 1u; ++k) result[k] = attempt[k];
+        result[pass_len + 1u] = 0;
+        *g_found = 1;
+        return;
+      }
+    }
+    if (pass_len + 2u < min_len) continue;
+    for (uint j = 0; j < dict_length; ++j) {
+      attempt[pass_len + 1u] = k_dict[j];
+      if (*g_found) return;
+      if (prsha3_224_compare(k_hash, attempt, (int)(pass_len + 2u))) {
+        for (uint k = 0; k < pass_len + 2u; ++k) result[k] = attempt[k];
+        result[pass_len + 2u] = 0;
+        *g_found = 1;
+        return;
+      }
     }
   }
 }

--- a/src/opencl/kernels/sha3_224.cl.h
+++ b/src/opencl/kernels/sha3_224.cl.h
@@ -149,25 +149,27 @@
 "    attempt[pos] = k_dict[idx % dict_length];\n"\
 "    idx /= dict_length;\n"\
 "  }\n"\
-"  if (pass_len >= min_len) {\n"\
-"    if (*g_found) return;\n"\
-"    if (prsha3_224_compare(k_hash, attempt, (int)pass_len)) {\n"\
-"      for (uint k = 0; k < pass_len; ++k) result[k] = attempt[k];\n"\
-"      result[pass_len] = 0;\n"\
-"      *g_found = 1;\n"\
-"      return;\n"\
-"    }\n"\
-"  }\n"\
-"  const uint attempt_len = pass_len + 1u;\n"\
-"  if (attempt_len < min_len) return;\n"\
 "  for (uint i = 0; i < dict_length; ++i) {\n"\
 "    attempt[pass_len] = k_dict[i];\n"\
-"    if (*g_found) return;\n"\
-"    if (prsha3_224_compare(k_hash, attempt, (int)attempt_len)) {\n"\
-"      for (uint k = 0; k < attempt_len; ++k) result[k] = attempt[k];\n"\
-"      result[attempt_len] = 0;\n"\
-"      *g_found = 1;\n"\
-"      return;\n"\
+"    if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {\n"\
+"      if (*g_found) return;\n"\
+"      if (prsha3_224_compare(k_hash, attempt, (int)(pass_len + 1u))) {\n"\
+"        for (uint k = 0; k < pass_len + 1u; ++k) result[k] = attempt[k];\n"\
+"        result[pass_len + 1u] = 0;\n"\
+"        *g_found = 1;\n"\
+"        return;\n"\
+"      }\n"\
+"    }\n"\
+"    if (pass_len + 2u < min_len) continue;\n"\
+"    for (uint j = 0; j < dict_length; ++j) {\n"\
+"      attempt[pass_len + 1u] = k_dict[j];\n"\
+"      if (*g_found) return;\n"\
+"      if (prsha3_224_compare(k_hash, attempt, (int)(pass_len + 2u))) {\n"\
+"        for (uint k = 0; k < pass_len + 2u; ++k) result[k] = attempt[k];\n"\
+"        result[pass_len + 2u] = 0;\n"\
+"        *g_found = 1;\n"\
+"        return;\n"\
+"      }\n"\
 "    }\n"\
 "  }\n"\
 "}\n"\

--- a/src/opencl/kernels/sha3_256.cl
+++ b/src/opencl/kernels/sha3_256.cl
@@ -149,25 +149,27 @@ __kernel void prsha3_256_kernel(__global uchar* result,
     attempt[pos] = k_dict[idx % dict_length];
     idx /= dict_length;
   }
-  if (pass_len >= min_len) {
-    if (*g_found) return;
-    if (prsha3_256_compare(k_hash, attempt, (int)pass_len)) {
-      for (uint k = 0; k < pass_len; ++k) result[k] = attempt[k];
-      result[pass_len] = 0;
-      *g_found = 1;
-      return;
-    }
-  }
-  const uint attempt_len = pass_len + 1u;
-  if (attempt_len < min_len) return;
   for (uint i = 0; i < dict_length; ++i) {
     attempt[pass_len] = k_dict[i];
-    if (*g_found) return;
-    if (prsha3_256_compare(k_hash, attempt, (int)attempt_len)) {
-      for (uint k = 0; k < attempt_len; ++k) result[k] = attempt[k];
-      result[attempt_len] = 0;
-      *g_found = 1;
-      return;
+    if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {
+      if (*g_found) return;
+      if (prsha3_256_compare(k_hash, attempt, (int)(pass_len + 1u))) {
+        for (uint k = 0; k < pass_len + 1u; ++k) result[k] = attempt[k];
+        result[pass_len + 1u] = 0;
+        *g_found = 1;
+        return;
+      }
+    }
+    if (pass_len + 2u < min_len) continue;
+    for (uint j = 0; j < dict_length; ++j) {
+      attempt[pass_len + 1u] = k_dict[j];
+      if (*g_found) return;
+      if (prsha3_256_compare(k_hash, attempt, (int)(pass_len + 2u))) {
+        for (uint k = 0; k < pass_len + 2u; ++k) result[k] = attempt[k];
+        result[pass_len + 2u] = 0;
+        *g_found = 1;
+        return;
+      }
     }
   }
 }

--- a/src/opencl/kernels/sha3_256.cl.h
+++ b/src/opencl/kernels/sha3_256.cl.h
@@ -149,25 +149,27 @@
 "    attempt[pos] = k_dict[idx % dict_length];\n"\
 "    idx /= dict_length;\n"\
 "  }\n"\
-"  if (pass_len >= min_len) {\n"\
-"    if (*g_found) return;\n"\
-"    if (prsha3_256_compare(k_hash, attempt, (int)pass_len)) {\n"\
-"      for (uint k = 0; k < pass_len; ++k) result[k] = attempt[k];\n"\
-"      result[pass_len] = 0;\n"\
-"      *g_found = 1;\n"\
-"      return;\n"\
-"    }\n"\
-"  }\n"\
-"  const uint attempt_len = pass_len + 1u;\n"\
-"  if (attempt_len < min_len) return;\n"\
 "  for (uint i = 0; i < dict_length; ++i) {\n"\
 "    attempt[pass_len] = k_dict[i];\n"\
-"    if (*g_found) return;\n"\
-"    if (prsha3_256_compare(k_hash, attempt, (int)attempt_len)) {\n"\
-"      for (uint k = 0; k < attempt_len; ++k) result[k] = attempt[k];\n"\
-"      result[attempt_len] = 0;\n"\
-"      *g_found = 1;\n"\
-"      return;\n"\
+"    if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {\n"\
+"      if (*g_found) return;\n"\
+"      if (prsha3_256_compare(k_hash, attempt, (int)(pass_len + 1u))) {\n"\
+"        for (uint k = 0; k < pass_len + 1u; ++k) result[k] = attempt[k];\n"\
+"        result[pass_len + 1u] = 0;\n"\
+"        *g_found = 1;\n"\
+"        return;\n"\
+"      }\n"\
+"    }\n"\
+"    if (pass_len + 2u < min_len) continue;\n"\
+"    for (uint j = 0; j < dict_length; ++j) {\n"\
+"      attempt[pass_len + 1u] = k_dict[j];\n"\
+"      if (*g_found) return;\n"\
+"      if (prsha3_256_compare(k_hash, attempt, (int)(pass_len + 2u))) {\n"\
+"        for (uint k = 0; k < pass_len + 2u; ++k) result[k] = attempt[k];\n"\
+"        result[pass_len + 2u] = 0;\n"\
+"        *g_found = 1;\n"\
+"        return;\n"\
+"      }\n"\
 "    }\n"\
 "  }\n"\
 "}\n"\

--- a/src/opencl/kernels/sha3_384.cl
+++ b/src/opencl/kernels/sha3_384.cl
@@ -149,25 +149,27 @@ __kernel void prsha3_384_kernel(__global uchar* result,
     attempt[pos] = k_dict[idx % dict_length];
     idx /= dict_length;
   }
-  if (pass_len >= min_len) {
-    if (*g_found) return;
-    if (prsha3_384_compare(k_hash, attempt, (int)pass_len)) {
-      for (uint k = 0; k < pass_len; ++k) result[k] = attempt[k];
-      result[pass_len] = 0;
-      *g_found = 1;
-      return;
-    }
-  }
-  const uint attempt_len = pass_len + 1u;
-  if (attempt_len < min_len) return;
   for (uint i = 0; i < dict_length; ++i) {
     attempt[pass_len] = k_dict[i];
-    if (*g_found) return;
-    if (prsha3_384_compare(k_hash, attempt, (int)attempt_len)) {
-      for (uint k = 0; k < attempt_len; ++k) result[k] = attempt[k];
-      result[attempt_len] = 0;
-      *g_found = 1;
-      return;
+    if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {
+      if (*g_found) return;
+      if (prsha3_384_compare(k_hash, attempt, (int)(pass_len + 1u))) {
+        for (uint k = 0; k < pass_len + 1u; ++k) result[k] = attempt[k];
+        result[pass_len + 1u] = 0;
+        *g_found = 1;
+        return;
+      }
+    }
+    if (pass_len + 2u < min_len) continue;
+    for (uint j = 0; j < dict_length; ++j) {
+      attempt[pass_len + 1u] = k_dict[j];
+      if (*g_found) return;
+      if (prsha3_384_compare(k_hash, attempt, (int)(pass_len + 2u))) {
+        for (uint k = 0; k < pass_len + 2u; ++k) result[k] = attempt[k];
+        result[pass_len + 2u] = 0;
+        *g_found = 1;
+        return;
+      }
     }
   }
 }

--- a/src/opencl/kernels/sha3_384.cl.h
+++ b/src/opencl/kernels/sha3_384.cl.h
@@ -149,25 +149,27 @@
 "    attempt[pos] = k_dict[idx % dict_length];\n"\
 "    idx /= dict_length;\n"\
 "  }\n"\
-"  if (pass_len >= min_len) {\n"\
-"    if (*g_found) return;\n"\
-"    if (prsha3_384_compare(k_hash, attempt, (int)pass_len)) {\n"\
-"      for (uint k = 0; k < pass_len; ++k) result[k] = attempt[k];\n"\
-"      result[pass_len] = 0;\n"\
-"      *g_found = 1;\n"\
-"      return;\n"\
-"    }\n"\
-"  }\n"\
-"  const uint attempt_len = pass_len + 1u;\n"\
-"  if (attempt_len < min_len) return;\n"\
 "  for (uint i = 0; i < dict_length; ++i) {\n"\
 "    attempt[pass_len] = k_dict[i];\n"\
-"    if (*g_found) return;\n"\
-"    if (prsha3_384_compare(k_hash, attempt, (int)attempt_len)) {\n"\
-"      for (uint k = 0; k < attempt_len; ++k) result[k] = attempt[k];\n"\
-"      result[attempt_len] = 0;\n"\
-"      *g_found = 1;\n"\
-"      return;\n"\
+"    if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {\n"\
+"      if (*g_found) return;\n"\
+"      if (prsha3_384_compare(k_hash, attempt, (int)(pass_len + 1u))) {\n"\
+"        for (uint k = 0; k < pass_len + 1u; ++k) result[k] = attempt[k];\n"\
+"        result[pass_len + 1u] = 0;\n"\
+"        *g_found = 1;\n"\
+"        return;\n"\
+"      }\n"\
+"    }\n"\
+"    if (pass_len + 2u < min_len) continue;\n"\
+"    for (uint j = 0; j < dict_length; ++j) {\n"\
+"      attempt[pass_len + 1u] = k_dict[j];\n"\
+"      if (*g_found) return;\n"\
+"      if (prsha3_384_compare(k_hash, attempt, (int)(pass_len + 2u))) {\n"\
+"        for (uint k = 0; k < pass_len + 2u; ++k) result[k] = attempt[k];\n"\
+"        result[pass_len + 2u] = 0;\n"\
+"        *g_found = 1;\n"\
+"        return;\n"\
+"      }\n"\
 "    }\n"\
 "  }\n"\
 "}\n"\

--- a/src/opencl/kernels/sha3_512.cl
+++ b/src/opencl/kernels/sha3_512.cl
@@ -149,25 +149,27 @@ __kernel void prsha3_512_kernel(__global uchar* result,
     attempt[pos] = k_dict[idx % dict_length];
     idx /= dict_length;
   }
-  if (pass_len >= min_len) {
-    if (*g_found) return;
-    if (prsha3_512_compare(k_hash, attempt, (int)pass_len)) {
-      for (uint k = 0; k < pass_len; ++k) result[k] = attempt[k];
-      result[pass_len] = 0;
-      *g_found = 1;
-      return;
-    }
-  }
-  const uint attempt_len = pass_len + 1u;
-  if (attempt_len < min_len) return;
   for (uint i = 0; i < dict_length; ++i) {
     attempt[pass_len] = k_dict[i];
-    if (*g_found) return;
-    if (prsha3_512_compare(k_hash, attempt, (int)attempt_len)) {
-      for (uint k = 0; k < attempt_len; ++k) result[k] = attempt[k];
-      result[attempt_len] = 0;
-      *g_found = 1;
-      return;
+    if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {
+      if (*g_found) return;
+      if (prsha3_512_compare(k_hash, attempt, (int)(pass_len + 1u))) {
+        for (uint k = 0; k < pass_len + 1u; ++k) result[k] = attempt[k];
+        result[pass_len + 1u] = 0;
+        *g_found = 1;
+        return;
+      }
+    }
+    if (pass_len + 2u < min_len) continue;
+    for (uint j = 0; j < dict_length; ++j) {
+      attempt[pass_len + 1u] = k_dict[j];
+      if (*g_found) return;
+      if (prsha3_512_compare(k_hash, attempt, (int)(pass_len + 2u))) {
+        for (uint k = 0; k < pass_len + 2u; ++k) result[k] = attempt[k];
+        result[pass_len + 2u] = 0;
+        *g_found = 1;
+        return;
+      }
     }
   }
 }

--- a/src/opencl/kernels/sha3_512.cl.h
+++ b/src/opencl/kernels/sha3_512.cl.h
@@ -149,25 +149,27 @@
 "    attempt[pos] = k_dict[idx % dict_length];\n"\
 "    idx /= dict_length;\n"\
 "  }\n"\
-"  if (pass_len >= min_len) {\n"\
-"    if (*g_found) return;\n"\
-"    if (prsha3_512_compare(k_hash, attempt, (int)pass_len)) {\n"\
-"      for (uint k = 0; k < pass_len; ++k) result[k] = attempt[k];\n"\
-"      result[pass_len] = 0;\n"\
-"      *g_found = 1;\n"\
-"      return;\n"\
-"    }\n"\
-"  }\n"\
-"  const uint attempt_len = pass_len + 1u;\n"\
-"  if (attempt_len < min_len) return;\n"\
 "  for (uint i = 0; i < dict_length; ++i) {\n"\
 "    attempt[pass_len] = k_dict[i];\n"\
-"    if (*g_found) return;\n"\
-"    if (prsha3_512_compare(k_hash, attempt, (int)attempt_len)) {\n"\
-"      for (uint k = 0; k < attempt_len; ++k) result[k] = attempt[k];\n"\
-"      result[attempt_len] = 0;\n"\
-"      *g_found = 1;\n"\
-"      return;\n"\
+"    if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {\n"\
+"      if (*g_found) return;\n"\
+"      if (prsha3_512_compare(k_hash, attempt, (int)(pass_len + 1u))) {\n"\
+"        for (uint k = 0; k < pass_len + 1u; ++k) result[k] = attempt[k];\n"\
+"        result[pass_len + 1u] = 0;\n"\
+"        *g_found = 1;\n"\
+"        return;\n"\
+"      }\n"\
+"    }\n"\
+"    if (pass_len + 2u < min_len) continue;\n"\
+"    for (uint j = 0; j < dict_length; ++j) {\n"\
+"      attempt[pass_len + 1u] = k_dict[j];\n"\
+"      if (*g_found) return;\n"\
+"      if (prsha3_512_compare(k_hash, attempt, (int)(pass_len + 2u))) {\n"\
+"        for (uint k = 0; k < pass_len + 2u; ++k) result[k] = attempt[k];\n"\
+"        result[pass_len + 2u] = 0;\n"\
+"        *g_found = 1;\n"\
+"        return;\n"\
+"      }\n"\
 "    }\n"\
 "  }\n"\
 "}\n"\

--- a/src/opencl/kernels/sha512.cl
+++ b/src/opencl/kernels/sha512.cl
@@ -274,25 +274,27 @@ __kernel void prsha512_kernel(__global uchar* result,
     attempt[pos] = k_dict[idx % dict_length];
     idx /= dict_length;
   }
-  if (pass_len >= min_len) {
-    if (*g_found) return;
-    if (prsha512_compare(k_hash, attempt, (int)pass_len)) {
-      for (uint k = 0; k < pass_len; ++k) result[k] = attempt[k];
-      result[pass_len] = 0;
-      *g_found = 1;
-      return;
-    }
-  }
-  const uint attempt_len = pass_len + 1u;
-  if (attempt_len < min_len) return;
   for (uint i = 0; i < dict_length; ++i) {
     attempt[pass_len] = k_dict[i];
-    if (*g_found) return;
-    if (prsha512_compare(k_hash, attempt, (int)attempt_len)) {
-      for (uint k = 0; k < attempt_len; ++k) result[k] = attempt[k];
-      result[attempt_len] = 0;
-      *g_found = 1;
-      return;
+    if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {
+      if (*g_found) return;
+      if (prsha512_compare(k_hash, attempt, (int)(pass_len + 1u))) {
+        for (uint k = 0; k < pass_len + 1u; ++k) result[k] = attempt[k];
+        result[pass_len + 1u] = 0;
+        *g_found = 1;
+        return;
+      }
+    }
+    if (pass_len + 2u < min_len) continue;
+    for (uint j = 0; j < dict_length; ++j) {
+      attempt[pass_len + 1u] = k_dict[j];
+      if (*g_found) return;
+      if (prsha512_compare(k_hash, attempt, (int)(pass_len + 2u))) {
+        for (uint k = 0; k < pass_len + 2u; ++k) result[k] = attempt[k];
+        result[pass_len + 2u] = 0;
+        *g_found = 1;
+        return;
+      }
     }
   }
 }

--- a/src/opencl/kernels/sha512.cl.h
+++ b/src/opencl/kernels/sha512.cl.h
@@ -274,25 +274,27 @@
 "    attempt[pos] = k_dict[idx % dict_length];\n"\
 "    idx /= dict_length;\n"\
 "  }\n"\
-"  if (pass_len >= min_len) {\n"\
-"    if (*g_found) return;\n"\
-"    if (prsha512_compare(k_hash, attempt, (int)pass_len)) {\n"\
-"      for (uint k = 0; k < pass_len; ++k) result[k] = attempt[k];\n"\
-"      result[pass_len] = 0;\n"\
-"      *g_found = 1;\n"\
-"      return;\n"\
-"    }\n"\
-"  }\n"\
-"  const uint attempt_len = pass_len + 1u;\n"\
-"  if (attempt_len < min_len) return;\n"\
 "  for (uint i = 0; i < dict_length; ++i) {\n"\
 "    attempt[pass_len] = k_dict[i];\n"\
-"    if (*g_found) return;\n"\
-"    if (prsha512_compare(k_hash, attempt, (int)attempt_len)) {\n"\
-"      for (uint k = 0; k < attempt_len; ++k) result[k] = attempt[k];\n"\
-"      result[attempt_len] = 0;\n"\
-"      *g_found = 1;\n"\
-"      return;\n"\
+"    if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {\n"\
+"      if (*g_found) return;\n"\
+"      if (prsha512_compare(k_hash, attempt, (int)(pass_len + 1u))) {\n"\
+"        for (uint k = 0; k < pass_len + 1u; ++k) result[k] = attempt[k];\n"\
+"        result[pass_len + 1u] = 0;\n"\
+"        *g_found = 1;\n"\
+"        return;\n"\
+"      }\n"\
+"    }\n"\
+"    if (pass_len + 2u < min_len) continue;\n"\
+"    for (uint j = 0; j < dict_length; ++j) {\n"\
+"      attempt[pass_len + 1u] = k_dict[j];\n"\
+"      if (*g_found) return;\n"\
+"      if (prsha512_compare(k_hash, attempt, (int)(pass_len + 2u))) {\n"\
+"        for (uint k = 0; k < pass_len + 2u; ++k) result[k] = attempt[k];\n"\
+"        result[pass_len + 2u] = 0;\n"\
+"        *g_found = 1;\n"\
+"        return;\n"\
+"      }\n"\
 "    }\n"\
 "  }\n"\
 "}\n"\

--- a/src/opencl/kernels/whirl.cl
+++ b/src/opencl/kernels/whirl.cl
@@ -177,25 +177,27 @@ __kernel void prwhirl_kernel(__global uchar* result,
     attempt[pos] = k_dict[idx % dict_length];
     idx /= dict_length;
   }
-  if (pass_len >= min_len) {
-    if (*g_found) return;
-    if (prwhirl_compare(k_hash, attempt, (int)pass_len)) {
-      for (uint k = 0; k < pass_len; ++k) result[k] = attempt[k];
-      result[pass_len] = 0;
-      *g_found = 1;
-      return;
-    }
-  }
-  const uint attempt_len = pass_len + 1u;
-  if (attempt_len < min_len) return;
   for (uint i = 0; i < dict_length; ++i) {
     attempt[pass_len] = k_dict[i];
-    if (*g_found) return;
-    if (prwhirl_compare(k_hash, attempt, (int)attempt_len)) {
-      for (uint k = 0; k < attempt_len; ++k) result[k] = attempt[k];
-      result[attempt_len] = 0;
-      *g_found = 1;
-      return;
+    if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {
+      if (*g_found) return;
+      if (prwhirl_compare(k_hash, attempt, (int)(pass_len + 1u))) {
+        for (uint k = 0; k < pass_len + 1u; ++k) result[k] = attempt[k];
+        result[pass_len + 1u] = 0;
+        *g_found = 1;
+        return;
+      }
+    }
+    if (pass_len + 2u < min_len) continue;
+    for (uint j = 0; j < dict_length; ++j) {
+      attempt[pass_len + 1u] = k_dict[j];
+      if (*g_found) return;
+      if (prwhirl_compare(k_hash, attempt, (int)(pass_len + 2u))) {
+        for (uint k = 0; k < pass_len + 2u; ++k) result[k] = attempt[k];
+        result[pass_len + 2u] = 0;
+        *g_found = 1;
+        return;
+      }
     }
   }
 }

--- a/src/opencl/kernels/whirl.cl.h
+++ b/src/opencl/kernels/whirl.cl.h
@@ -177,25 +177,27 @@
 "    attempt[pos] = k_dict[idx % dict_length];\n"\
 "    idx /= dict_length;\n"\
 "  }\n"\
-"  if (pass_len >= min_len) {\n"\
-"    if (*g_found) return;\n"\
-"    if (prwhirl_compare(k_hash, attempt, (int)pass_len)) {\n"\
-"      for (uint k = 0; k < pass_len; ++k) result[k] = attempt[k];\n"\
-"      result[pass_len] = 0;\n"\
-"      *g_found = 1;\n"\
-"      return;\n"\
-"    }\n"\
-"  }\n"\
-"  const uint attempt_len = pass_len + 1u;\n"\
-"  if (attempt_len < min_len) return;\n"\
 "  for (uint i = 0; i < dict_length; ++i) {\n"\
 "    attempt[pass_len] = k_dict[i];\n"\
-"    if (*g_found) return;\n"\
-"    if (prwhirl_compare(k_hash, attempt, (int)attempt_len)) {\n"\
-"      for (uint k = 0; k < attempt_len; ++k) result[k] = attempt[k];\n"\
-"      result[attempt_len] = 0;\n"\
-"      *g_found = 1;\n"\
-"      return;\n"\
+"    if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {\n"\
+"      if (*g_found) return;\n"\
+"      if (prwhirl_compare(k_hash, attempt, (int)(pass_len + 1u))) {\n"\
+"        for (uint k = 0; k < pass_len + 1u; ++k) result[k] = attempt[k];\n"\
+"        result[pass_len + 1u] = 0;\n"\
+"        *g_found = 1;\n"\
+"        return;\n"\
+"      }\n"\
+"    }\n"\
+"    if (pass_len + 2u < min_len) continue;\n"\
+"    for (uint j = 0; j < dict_length; ++j) {\n"\
+"      attempt[pass_len + 1u] = k_dict[j];\n"\
+"      if (*g_found) return;\n"\
+"      if (prwhirl_compare(k_hash, attempt, (int)(pass_len + 2u))) {\n"\
+"        for (uint k = 0; k < pass_len + 2u; ++k) result[k] = attempt[k];\n"\
+"        result[pass_len + 2u] = 0;\n"\
+"        *g_found = 1;\n"\
+"        return;\n"\
+"      }\n"\
 "    }\n"\
 "  }\n"\
 "}\n"\

--- a/src/opencl/ocl_common.c
+++ b/src/opencl/ocl_common.c
@@ -161,6 +161,10 @@ void hc_ocl_algo_run(hc_ocl_algo_t* algo, gpu_tread_ctx_t* ctx, size_t dict_len)
     api->clSetKernelArg(algo->kernel, 6, sizeof(cl_uint), &pass_len);
     api->clSetKernelArg(algo->kernel, 7, sizeof(cl_uint), &cl_dict_len);
     api->clSetKernelArg(algo->kernel, 8, sizeof(cl_uint), &cl_min_len);
+    if (algo->pass_wide_arg) {
+        const cl_uint use_wide = ctx->use_wide_pass_ ? 1u : 0u;
+        api->clSetKernelArg(algo->kernel, 9, sizeof(cl_uint), &use_wide);
+    }
 
     size_t local = threads;
     size_t global = ((size_t)count + local - 1) / local * local;

--- a/src/opencl/ocl_common.h
+++ b/src/opencl/ocl_common.h
@@ -18,6 +18,8 @@ typedef struct hc_ocl_algo {
     cl_mem found_buf;
     size_t hash_len;
     int ready;
+    /** If non-zero, kernel arg 9 is ctx->use_wide_pass_ (NTLM / md4). */
+    int pass_wide_arg;
 } hc_ocl_algo_t;
 
 /** Build/cache program+kernel; upload dict/hash; alloc result/found. */

--- a/src/opencl/ocl_md4.c
+++ b/src/opencl/ocl_md4.c
@@ -25,6 +25,7 @@ void md4_on_gpu_prepare(int device_ix, const unsigned char* dict, size_t dict_le
                         const unsigned char* hash, gpu_tread_ctx_t* ctx) {
     (void)device_ix;
     hc_ocl_set_active_cleanup(&md4_cleanup);
+    g_md4.pass_wide_arg = 1;
     (void)hc_ocl_algo_prepare(&g_md4, k_md4_src, "prmd4_kernel", dict, dict_len, hash, 16, ctx);
 }
 

--- a/src/opencl/ocl_shim.c
+++ b/src/opencl/ocl_shim.c
@@ -6,6 +6,8 @@ BOOL gpu_get_device_props(int device_ix, device_props_t* prop) { return ocl_gpu_
 
 BOOL gpu_can_use_gpu(void) { return ocl_gpu_can_use_gpu(); }
 
+BOOL gpu_is_opencl(void) { return ocl_gpu_can_use_gpu(); }
+
 int gpu_driver_version(void) { return ocl_gpu_driver_version(); }
 
 int gpu_runtime_version(void) { return ocl_gpu_runtime_version(); }


### PR DESCRIPTION
NTLM needs UTF-16LE on OpenCL md4; expand kernels to cpi=2 like md5; cap heavy batches so Intel OpenCL does not drop hits; skip OpenCL GPU for factor>=4 algos so short cracks keep multi-CPU wall time.