### PR TITLE
fix(gpu): speed up SHA-3 CUDA and pin host to one thread

### DIFF
--- a/src/cuda/sha3.cu
+++ b/src/cuda/sha3.cu
@@ -1,6 +1,10 @@
 /*!
  * \brief   SHA-3 / Keccak CUDA brute-force (short passwords, one block).
  * Copyright: (c) Alexander Egorov 2009-2026
+ *
+ * Keccak state lives in scalar registers (not a uint64_t[25] array). On sm_75
+ * an array form spills ~200 B/thread to local memory and the kernel is no
+ * faster than a CPU core; scalars keep the permutation in-register.
  */
 
 #include <stdint.h>
@@ -10,7 +14,6 @@
 
 #define ROTL64(x, n) (((x) << (n)) | ((x) >> (64 - (n))))
 #define MAX_HASH_LEN 64
-#define MAX_RATE 144
 
 __constant__ static unsigned char k_dict[CHAR_MAX];
 __constant__ static unsigned char k_hash[MAX_HASH_LEN];
@@ -24,120 +27,156 @@ __constant__ static const uint64_t k_rc[24] = {
     UINT64_C(0x8000000080008081), UINT64_C(0x8000000000008080), UINT64_C(0x0000000080000001), UINT64_C(0x8000000080008008),
 };
 
-__device__ __forceinline__ void prkeccak_f1600(uint64_t* A) {
-#pragma unroll 1
-    for (int round = 0; round < 24; round++) {
-        uint64_t C[5], D[5];
-#pragma unroll
-        for (int x = 0; x < 5; x++) {
-            C[x] = A[x] ^ A[x + 5] ^ A[x + 10] ^ A[x + 15] ^ A[x + 20];
-        }
-        D[0] = ROTL64(C[1], 1) ^ C[4];
-        D[1] = ROTL64(C[2], 1) ^ C[0];
-        D[2] = ROTL64(C[3], 1) ^ C[1];
-        D[3] = ROTL64(C[4], 1) ^ C[2];
-        D[4] = ROTL64(C[0], 1) ^ C[3];
-#pragma unroll
-        for (int x = 0; x < 5; x++) {
-            A[x] ^= D[x];
-            A[x + 5] ^= D[x];
-            A[x + 10] ^= D[x];
-            A[x + 15] ^= D[x];
-            A[x + 20] ^= D[x];
-        }
+/// One Keccak-f1600 round. a00..a04 = linear state[0..4], a10..=state[5..], …
+/// Rho+pi fusion matches the array implementation in this file's history.
+#define KECCAK_ROUND(rc)                                                                                 \
+    do {                                                                                                 \
+        const uint64_t c0 = a00 ^ a10 ^ a20 ^ a30 ^ a40;                                                 \
+        const uint64_t c1 = a01 ^ a11 ^ a21 ^ a31 ^ a41;                                                 \
+        const uint64_t c2 = a02 ^ a12 ^ a22 ^ a32 ^ a42;                                                 \
+        const uint64_t c3 = a03 ^ a13 ^ a23 ^ a33 ^ a43;                                                 \
+        const uint64_t c4 = a04 ^ a14 ^ a24 ^ a34 ^ a44;                                                 \
+        const uint64_t d0 = ROTL64(c1, 1) ^ c4;                                                          \
+        const uint64_t d1 = ROTL64(c2, 1) ^ c0;                                                          \
+        const uint64_t d2 = ROTL64(c3, 1) ^ c1;                                                          \
+        const uint64_t d3 = ROTL64(c4, 1) ^ c2;                                                          \
+        const uint64_t d4 = ROTL64(c0, 1) ^ c3;                                                          \
+        const uint64_t b00 = (a00 ^ d0);                                                                 \
+        const uint64_t b01 = ROTL64(a11 ^ d1, 44);                                                       \
+        const uint64_t b02 = ROTL64(a22 ^ d2, 43);                                                       \
+        const uint64_t b03 = ROTL64(a33 ^ d3, 21);                                                       \
+        const uint64_t b04 = ROTL64(a44 ^ d4, 14);                                                       \
+        const uint64_t b10 = ROTL64(a03 ^ d3, 28);                                                       \
+        const uint64_t b11 = ROTL64(a14 ^ d4, 20);                                                       \
+        const uint64_t b12 = ROTL64(a20 ^ d0, 3);                                                        \
+        const uint64_t b13 = ROTL64(a31 ^ d1, 45);                                                       \
+        const uint64_t b14 = ROTL64(a42 ^ d2, 61);                                                       \
+        const uint64_t b20 = ROTL64(a01 ^ d1, 1);                                                        \
+        const uint64_t b21 = ROTL64(a12 ^ d2, 6);                                                        \
+        const uint64_t b22 = ROTL64(a23 ^ d3, 25);                                                       \
+        const uint64_t b23 = ROTL64(a34 ^ d4, 8);                                                        \
+        const uint64_t b24 = ROTL64(a40 ^ d0, 18);                                                       \
+        const uint64_t b30 = ROTL64(a04 ^ d4, 27);                                                       \
+        const uint64_t b31 = ROTL64(a10 ^ d0, 36);                                                       \
+        const uint64_t b32 = ROTL64(a21 ^ d1, 10);                                                       \
+        const uint64_t b33 = ROTL64(a32 ^ d2, 15);                                                       \
+        const uint64_t b34 = ROTL64(a43 ^ d3, 56);                                                       \
+        const uint64_t b40 = ROTL64(a02 ^ d2, 62);                                                       \
+        const uint64_t b41 = ROTL64(a13 ^ d3, 55);                                                       \
+        const uint64_t b42 = ROTL64(a24 ^ d4, 39);                                                       \
+        const uint64_t b43 = ROTL64(a30 ^ d0, 41);                                                       \
+        const uint64_t b44 = ROTL64(a41 ^ d1, 2);                                                        \
+        a00 = b00 ^ ((~b01) & b02) ^ (rc);                                                               \
+        a01 = b01 ^ ((~b02) & b03);                                                                      \
+        a02 = b02 ^ ((~b03) & b04);                                                                      \
+        a03 = b03 ^ ((~b04) & b00);                                                                      \
+        a04 = b04 ^ ((~b00) & b01);                                                                      \
+        a10 = b10 ^ ((~b11) & b12);                                                                      \
+        a11 = b11 ^ ((~b12) & b13);                                                                      \
+        a12 = b12 ^ ((~b13) & b14);                                                                      \
+        a13 = b13 ^ ((~b14) & b10);                                                                      \
+        a14 = b14 ^ ((~b10) & b11);                                                                      \
+        a20 = b20 ^ ((~b21) & b22);                                                                      \
+        a21 = b21 ^ ((~b22) & b23);                                                                      \
+        a22 = b22 ^ ((~b23) & b24);                                                                      \
+        a23 = b23 ^ ((~b24) & b20);                                                                      \
+        a24 = b24 ^ ((~b20) & b21);                                                                      \
+        a30 = b30 ^ ((~b31) & b32);                                                                      \
+        a31 = b31 ^ ((~b32) & b33);                                                                      \
+        a32 = b32 ^ ((~b33) & b34);                                                                      \
+        a33 = b33 ^ ((~b34) & b30);                                                                      \
+        a34 = b34 ^ ((~b30) & b31);                                                                      \
+        a40 = b40 ^ ((~b41) & b42);                                                                      \
+        a41 = b41 ^ ((~b42) & b43);                                                                      \
+        a42 = b42 ^ ((~b43) & b44);                                                                      \
+        a43 = b43 ^ ((~b44) & b40);                                                                      \
+        a44 = b44 ^ ((~b40) & b41);                                                                      \
+    } while (0)
 
-        A[1] = ROTL64(A[1], 1);
-        A[2] = ROTL64(A[2], 62);
-        A[3] = ROTL64(A[3], 28);
-        A[4] = ROTL64(A[4], 27);
-        A[5] = ROTL64(A[5], 36);
-        A[6] = ROTL64(A[6], 44);
-        A[7] = ROTL64(A[7], 6);
-        A[8] = ROTL64(A[8], 55);
-        A[9] = ROTL64(A[9], 20);
-        A[10] = ROTL64(A[10], 3);
-        A[11] = ROTL64(A[11], 10);
-        A[12] = ROTL64(A[12], 43);
-        A[13] = ROTL64(A[13], 25);
-        A[14] = ROTL64(A[14], 39);
-        A[15] = ROTL64(A[15], 41);
-        A[16] = ROTL64(A[16], 45);
-        A[17] = ROTL64(A[17], 15);
-        A[18] = ROTL64(A[18], 21);
-        A[19] = ROTL64(A[19], 8);
-        A[20] = ROTL64(A[20], 18);
-        A[21] = ROTL64(A[21], 2);
-        A[22] = ROTL64(A[22], 61);
-        A[23] = ROTL64(A[23], 56);
-        A[24] = ROTL64(A[24], 14);
+#define KECCAK_F1600()                                                                                   \
+    do {                                                                                                 \
+        KECCAK_ROUND(k_rc[0]);                                                                           \
+        KECCAK_ROUND(k_rc[1]);                                                                           \
+        KECCAK_ROUND(k_rc[2]);                                                                           \
+        KECCAK_ROUND(k_rc[3]);                                                                           \
+        KECCAK_ROUND(k_rc[4]);                                                                           \
+        KECCAK_ROUND(k_rc[5]);                                                                           \
+        KECCAK_ROUND(k_rc[6]);                                                                           \
+        KECCAK_ROUND(k_rc[7]);                                                                           \
+        KECCAK_ROUND(k_rc[8]);                                                                           \
+        KECCAK_ROUND(k_rc[9]);                                                                           \
+        KECCAK_ROUND(k_rc[10]);                                                                          \
+        KECCAK_ROUND(k_rc[11]);                                                                          \
+        KECCAK_ROUND(k_rc[12]);                                                                          \
+        KECCAK_ROUND(k_rc[13]);                                                                          \
+        KECCAK_ROUND(k_rc[14]);                                                                          \
+        KECCAK_ROUND(k_rc[15]);                                                                          \
+        KECCAK_ROUND(k_rc[16]);                                                                          \
+        KECCAK_ROUND(k_rc[17]);                                                                          \
+        KECCAK_ROUND(k_rc[18]);                                                                          \
+        KECCAK_ROUND(k_rc[19]);                                                                          \
+        KECCAK_ROUND(k_rc[20]);                                                                          \
+        KECCAK_ROUND(k_rc[21]);                                                                          \
+        KECCAK_ROUND(k_rc[22]);                                                                          \
+        KECCAK_ROUND(k_rc[23]);                                                                          \
+    } while (0)
 
-        {
-            uint64_t A1 = A[1];
-            A[1] = A[6];
-            A[6] = A[9];
-            A[9] = A[22];
-            A[22] = A[14];
-            A[14] = A[20];
-            A[20] = A[2];
-            A[2] = A[12];
-            A[12] = A[13];
-            A[13] = A[19];
-            A[19] = A[23];
-            A[23] = A[15];
-            A[15] = A[4];
-            A[4] = A[24];
-            A[24] = A[21];
-            A[21] = A[8];
-            A[8] = A[16];
-            A[16] = A[5];
-            A[5] = A[3];
-            A[3] = A[18];
-            A[18] = A[17];
-            A[17] = A[11];
-            A[11] = A[7];
-            A[7] = A[10];
-            A[10] = A1;
+/// Absorb a short password (len < 16 ≤ every SHA-3 rate) into lane scalars.
+/// Layout: a00..a04 = state[0..4], a10..a14 = state[5..9], … (row-major sheets).
+__device__ __forceinline__ void prsha3_absorb_short(
+    uint64_t& a00, uint64_t& a01, uint64_t& a02, uint64_t& a03, uint64_t& a04,
+    uint64_t& a10, uint64_t& a11, uint64_t& a12, uint64_t& a13, uint64_t& a14,
+    uint64_t& a20, uint64_t& a21, uint64_t& a22, uint64_t& a23, uint64_t& a24,
+    uint64_t& a30, uint64_t& a31, uint64_t& a32, uint64_t& a33, uint64_t& a34,
+    uint64_t& a40, uint64_t& a41, uint64_t& a42, uint64_t& a43, uint64_t& a44,
+    const uint8_t* message, int len, unsigned rate, uint8_t pad) {
+    a00 = a01 = a02 = a03 = a04 = 0;
+    a10 = a11 = a12 = a13 = a14 = 0;
+    a20 = a21 = a22 = a23 = a24 = 0;
+    a30 = a31 = a32 = a33 = a34 = 0;
+    a40 = a41 = a42 = a43 = a44 = 0;
+
+    uint64_t lane0 = 0;
+    uint64_t lane1 = 0;
+    for (int i = 0; i < len; i++) {
+        if (i < 8) {
+            lane0 |= static_cast<uint64_t>(message[i]) << (i << 3);
+        } else {
+            lane1 |= static_cast<uint64_t>(message[i]) << ((i - 8) << 3);
         }
-
-#pragma unroll
-        for (int i = 0; i < 25; i += 5) {
-            uint64_t A0 = A[0 + i], A1 = A[1 + i];
-            A[0 + i] ^= ~A1 & A[2 + i];
-            A[1 + i] ^= ~A[2 + i] & A[3 + i];
-            A[2 + i] ^= ~A[3 + i] & A[4 + i];
-            A[3 + i] ^= ~A[4 + i] & A0;
-            A[4 + i] ^= ~A0 & A1;
-        }
-
-        A[0] ^= k_rc[round];
     }
+    if (len < 8) {
+        lane0 |= static_cast<uint64_t>(pad) << (len << 3);
+    } else {
+        lane1 |= static_cast<uint64_t>(pad) << ((len - 8) << 3);
+    }
+    a00 = lane0;
+    a01 = lane1;
+
+    // Multi-rate 0x80 at byte (rate - 1). rate is always a multiple of 8.
+    // last ∈ {8,12,16,17} for rates {72,104,136,144} → lanes a13,a22,a31,a32.
+    const unsigned last = (rate - 1u) >> 3;
+    const uint64_t sep = UINT64_C(0x80) << 56;
+    if (last == 8) a13 ^= sep;
+    else if (last == 12) a22 ^= sep;
+    else if (last == 16) a31 ^= sep;
+    else a32 ^= sep; // last == 17
 }
 
-__device__ __forceinline__ void prsha3_hash(const uint8_t* message, size_t len, uint8_t* out,
-                                             unsigned rate, unsigned out_len, uint8_t pad) {
-    uint64_t state[25] = {};
-    uint8_t block[MAX_RATE] = {};
-    memcpy(block, message, len);
-    block[len] |= pad;
-    block[rate - 1] |= 0x80;
-
-    const unsigned nq = rate / 8;
-    for (unsigned i = 0; i < nq; i++) {
-        const unsigned o = i * 8;
-        state[i] ^= static_cast<uint64_t>(block[o + 0])
-            | (static_cast<uint64_t>(block[o + 1]) << 8)
-            | (static_cast<uint64_t>(block[o + 2]) << 16)
-            | (static_cast<uint64_t>(block[o + 3]) << 24)
-            | (static_cast<uint64_t>(block[o + 4]) << 32)
-            | (static_cast<uint64_t>(block[o + 5]) << 40)
-            | (static_cast<uint64_t>(block[o + 6]) << 48)
-            | (static_cast<uint64_t>(block[o + 7]) << 56);
+__device__ __forceinline__ BOOL prsha3_digest_eq(
+    uint64_t a00, uint64_t a01, uint64_t a02, uint64_t a03, uint64_t a04,
+    uint64_t a10, uint64_t a11, uint64_t a12, uint64_t a13, uint64_t a14,
+    uint64_t a20, uint64_t a21, uint64_t a22, uint64_t a23, uint64_t a24,
+    uint64_t a30, uint64_t a31, uint64_t a32, uint64_t a33, uint64_t a34,
+    uint64_t a40, uint64_t a41, uint64_t a42, uint64_t a43, uint64_t a44,
+    unsigned hash_len) {
+    // Output lanes are a00,a01,a02,... in linear index order (x+5y).
+    const uint64_t lanes[8] = { a00, a01, a02, a03, a04, a10, a11, a12 };
+    for (unsigned i = 0; i < hash_len; i++) {
+        const uint8_t b = static_cast<uint8_t>(lanes[i >> 3] >> ((i & 7) << 3));
+        if (b != k_hash[i]) return FALSE;
     }
-    prkeccak_f1600(state);
-
-    for (unsigned i = 0; i < out_len; i++) {
-        out[i] = static_cast<uint8_t>(state[i >> 3] >> ((i & 7) << 3));
-    }
+    return TRUE;
 }
 
 __host__ static void prsha3_prepare(int device_ix, const unsigned char* dict, size_t dict_len,
@@ -150,13 +189,17 @@ __host__ static void prsha3_prepare(int device_ix, const unsigned char* dict, si
 }
 
 #define SHA3_VARIANT(name, rate, hash_len, pad)                                                          \
-__device__ static BOOL pr##name##_compare(unsigned char* password, const int length, uint8_t* hash) {    \
-    prsha3_hash(password, length, hash, rate, hash_len, pad);                                            \
-    BOOL result = TRUE;                                                                                  \
-    for (int i = 0; i < (int)(hash_len) && result; ++i) {                                                \
-        result &= hash[i] == k_hash[i];                                                                  \
-    }                                                                                                    \
-    return result;                                                                                       \
+__device__ static BOOL pr##name##_compare(unsigned char* password, const int length) {                   \
+    uint64_t a00, a01, a02, a03, a04, a10, a11, a12, a13, a14;                                           \
+    uint64_t a20, a21, a22, a23, a24, a30, a31, a32, a33, a34;                                           \
+    uint64_t a40, a41, a42, a43, a44;                                                                    \
+    prsha3_absorb_short(a00, a01, a02, a03, a04, a10, a11, a12, a13, a14,                                \
+                        a20, a21, a22, a23, a24, a30, a31, a32, a33, a34,                                \
+                        a40, a41, a42, a43, a44, password, length, rate, pad);                           \
+    KECCAK_F1600();                                                                                      \
+    return prsha3_digest_eq(a00, a01, a02, a03, a04, a10, a11, a12, a13, a14,                            \
+                            a20, a21, a22, a23, a24, a30, a31, a32, a33, a34,                            \
+                            a40, a41, a42, a43, a44, hash_len);                                          \
 }                                                                                                        \
 __global__ static void pr##name##_kernel(unsigned char* result, const uint64_t start, const uint32_t count,\
                                          const uint32_t pass_len, const uint32_t dict_length,             \
@@ -165,7 +208,6 @@ __global__ static void pr##name##_kernel(unsigned char* result, const uint64_t s
     if (ix >= count) return;                                                                             \
     uint64_t idx = start + ix;                                                                           \
     unsigned char attempt[GPU_ATTEMPT_SIZE];                                                              \
-    uint8_t hash[hash_len];                                                                              \
     for (int pos = (int)pass_len - 1; pos >= 0; --pos) {                                                 \
         attempt[pos] = k_dict[idx % dict_length];                                                        \
         idx /= dict_length;                                                                              \
@@ -173,7 +215,7 @@ __global__ static void pr##name##_kernel(unsigned char* result, const uint64_t s
     for (uint32_t i = 0; i < dict_length; ++i) {                                                         \
         attempt[pass_len] = k_dict[i];                                                                   \
         if (pass_len + 1u == 4u && pass_len + 1u >= min_len) {                                           \
-            if (pr##name##_compare(attempt, (int)(pass_len + 1u), hash)) {                               \
+            if (pr##name##_compare(attempt, (int)(pass_len + 1u))) {                                     \
                 memcpy(result, attempt, pass_len + 1u);                                                  \
                 return;                                                                                  \
             }                                                                                            \
@@ -181,7 +223,7 @@ __global__ static void pr##name##_kernel(unsigned char* result, const uint64_t s
         if (pass_len + 2u < min_len) continue;                                                           \
         for (uint32_t j = 0; j < dict_length; ++j) {                                                     \
             attempt[pass_len + 1u] = k_dict[j];                                                          \
-            if (pr##name##_compare(attempt, (int)(pass_len + 2u), hash)) {                               \
+            if (pr##name##_compare(attempt, (int)(pass_len + 2u))) {                                     \
                 memcpy(result, attempt, pass_len + 2u);                                                  \
                 return;                                                                                  \
             }                                                                                            \

--- a/src/hc/bf.zig
+++ b/src/hc/bf.zig
@@ -388,14 +388,14 @@ fn runBruteForce(
     }
     const gpu_max_len: u32 = gpuMaxPasswordLen();
 
-    // Light kernels (factor 1–2) beat multi-CPU on GPU — pin to 1 host thread.
-    // Heavy kernels (factor >= 4): on OpenCL (dual binary that fell back to CL)
-    // skip GPU so wall time matches classic multi-CPU; CUDA keeps GPU + threads.
+    // With GPU: pin to 1 host thread so CPU does not race the device.
+    // Heavy kernels (factor >= 4) on OpenCL: skip GPU (dual binary CL fallback
+    // loses short cracks / contends on iGPU) and keep multi-CPU.
     var num_threads: u32 = num_threads_in;
     if (has_gpu) {
         if (gpu_factor >= 4 and c.gpu_is_opencl()) {
             has_gpu = false;
-        } else if (gpu_factor < 4) {
+        } else {
             num_threads = 1;
         }
     }

--- a/src/hc/gpu.zig
+++ b/src/hc/gpu.zig
@@ -73,8 +73,8 @@ const gpu_algos = [_]GpuAlgoEntry{
     gpuEntry("sha1", @ptrCast(&c.sha1_run_on_gpu), @ptrCast(&c.sha1_on_gpu_prepare), 1, 2),
     gpuEntry("sha256", @ptrCast(&c.sha256_run_on_gpu), @ptrCast(&c.sha256_on_gpu_prepare), 2, 2),
     gpuEntry("sha224", @ptrCast(&c.sha224_run_on_gpu), @ptrCast(&c.sha224_on_gpu_prepare), 2, 2),
-    // factor 4: on OpenCL these lose short cracks to multi-CPU (and contend on
-    // iGPU); bf.zig skips GPU for OpenCL+factor>=4. CUDA still runs them on GPU.
+    // factor 4: OpenCL skips GPU (short cracks lose to multi-CPU / iGPU
+    // contention). CUDA runs them with 1 host thread (same as light kernels).
     gpuEntry("sha-3-224", @ptrCast(&c.sha3_224_run_on_gpu), @ptrCast(&c.sha3_224_on_gpu_prepare), 4, 2),
     gpuEntry("sha-3-256", @ptrCast(&c.sha3_256_run_on_gpu), @ptrCast(&c.sha3_256_on_gpu_prepare), 4, 2),
     gpuEntry("sha-3-384", @ptrCast(&c.sha3_384_run_on_gpu), @ptrCast(&c.sha3_384_on_gpu_prepare), 4, 2),
@@ -94,8 +94,7 @@ const gpu_algos = [_]GpuAlgoEntry{
     gpuEntry("ripemd320", @ptrCast(&c.rmd320_run_on_gpu), @ptrCast(&c.rmd320_on_gpu_prepare), 4, 2),
     gpuEntry("blake2s", @ptrCast(&c.blake2s_run_on_gpu), @ptrCast(&c.blake2s_on_gpu_prepare), 4, 2),
     gpuEntry("blake2b", @ptrCast(&c.blake2b_run_on_gpu), @ptrCast(&c.blake2b_on_gpu_prepare), 4, 2),
-    // cpi=0 = exact-length kernel (no serial expand). factor 4 keeps multi-CPU
-    // as a floor for tiger (heavy exact-length search).
+    // cpi=0 = exact-length kernel (no serial expand). factor 4: OpenCL skips GPU.
     gpuEntry("tiger", @ptrCast(&c.tiger_run_on_gpu), @ptrCast(&c.tiger_on_gpu_prepare), 4, 0),
     gpuEntry("tiger2", @ptrCast(&c.tiger2_run_on_gpu), @ptrCast(&c.tiger2_on_gpu_prepare), 4, 0),
     gpuEntry("whirlpool", @ptrCast(&c.whirl_run_on_gpu), @ptrCast(&c.whirl_on_gpu_prepare), 4, 2),


### PR DESCRIPTION
Keep Keccak state in registers instead of local memory, and stop racing multi-CPU against CUDA for heavy kernels.