### PR TITLE
Fixes

### DIFF
--- a/docs/l2h-semantics.md
+++ b/docs/l2h-semantics.md
@@ -216,7 +216,7 @@ Which properties are available depends entirely on the **runtime kind** of the r
 | `File` | `readable` | `Bool` | `true` if the path opens as a regular file (probe open+stat); `false` on permission/missing/non-file; never raises I/O. Use `where f.readable` before `size` / `<hash>` |
 | `File` | `<hash>` | `String` | Hex digest of file contents (honoring that value's window); `<hash>` can be any algorithm name `hc` knows (`md5`, `sha1`, `tiger`, …) |
 | `String` | `size` | `Int` | Length in bytes (UTF-8 payload length as stored) |
-| `String` | `<hash>` | `String` | Hex digest of the string's bytes |
+| `String` | `<hash>` | `String` | Hex digest of the string's bytes; UTF-16-widening algorithms (e.g. NTLM) require a valid UTF-8 payload and raise a runtime error otherwise |
 | `Hash` | `<hash>` | `String` | **Restore** path: treats the bound digest as the input digest for algorithm `<hash>` (same meaning as legacy `from hash … select x.md5`). This is *not* "hash the digest characters as a string" |
 | `Dir` | `path` | `String` | Path identifying the directory (no I/O; projects the bound path). Use `from file f in d` (or `d.tree()` / `d.tree(n)`) to reach the files inside |
 | `Record` | field name | field value | Fields introduced by `{…}`, `let`, or join shaping |

--- a/docs/l2h-semantics.md
+++ b/docs/l2h-semantics.md
@@ -444,7 +444,7 @@ from string t in 'xyz' where t.md5 != h select t;
 
 Inside clauses you write expressions, and the supported forms are:
 
-- String, integer, and boolean literals, including bare `true` / `false` in `where` and `select`, and signed integer literals like `-1`
+- String, integer, and boolean literals, including bare `true` / `false` in `where` and `select`, and signed integer literals like `-1`. Integers are 64-bit; a literal outside `[-2^63, 2^63-1]` is a compile error ("integer literal out of range")
 - String literals `'…'` / `"…"` have no escapes, so a path like `'c:\Windows'` keeps its backslash
 - Byte-string literals `b'…'` and `b"…"` are the same thing and support `\xNN`, `\\`, `\'`, `\"`, `\n`, `\r`, `\t`. Bad or truncated escapes are compile errors. They still evaluate to `String`; digests from hash properties stay ASCII hex (`is_digest`)
 - A range identifier on its own

--- a/src/hc/bf.zig
+++ b/src/hc/bf.zig
@@ -420,6 +420,9 @@ fn runBruteForce(
             // paths a CUDA driver can report, so the signed->usize cast is safe.
             const n_gpu: usize = @intCast(count_props.device_count);
             const gpu_ctxs = try arena.alloc(c.gpu_tread_ctx_t, n_gpu);
+            // The post-join scan reads every slot; a device skipped by a failed
+            // gpu_get_device_props must read as not-found, not arena garbage.
+            @memset(std.mem.sliceAsBytes(gpu_ctxs), 0);
             var gpu_threads = try arena.alloc(?std.Thread, n_gpu);
             @memset(gpu_threads, null);
             defer joinSpawnedThreads(gpu_threads);

--- a/src/l2h/compile_test.zig
+++ b/src/l2h/compile_test.zig
@@ -609,6 +609,29 @@ test "compile+run invalid property reports runtime error" {
     try std.testing.expectEqualStrings("invalid property for this value type", got.err);
 }
 
+test "compile+run non-UTF-8 string payload hash reports payload error" {
+    // Arrange — NTLM widens the payload to UTF-16LE; a byte literal can carry
+    // non-UTF-8 bytes, which must surface as a payload error, not an I/O one.
+    const query = "from string s in b'\\xDE\\xAD\\xBE\\xEF' select s.ntlm;";
+
+    // Act
+    const got = try runQuery(query);
+
+    // Assert
+    try std.testing.expectEqualStrings("string payload is not valid UTF-8 for this algorithm", got.err);
+}
+
+test "compile+run non-UTF-8 payload hash-check reports payload error" {
+    // Arrange — same constraint via the hash-check method form (§4.8).
+    const query = "from string s in b'\\xFF' where s.ntlm('00000000000000000000000000000000') select s;";
+
+    // Act
+    const got = try runQuery(query);
+
+    // Assert
+    try std.testing.expectEqualStrings("string payload is not valid UTF-8 for this algorithm", got.err);
+}
+
 test "compile+run undefined select name reports undefined name" {
     const query = "from string s in 'abc' select missing;";
     const got = try runQuery(query);

--- a/src/l2h/compile_test.zig
+++ b/src/l2h/compile_test.zig
@@ -2697,3 +2697,51 @@ test "compile+run join source name shadowed by pipeline is not cached" {
     try std.testing.expectEqualStrings("", got.err);
     try std.testing.expectEqualStrings("a\nbb\n", got.out);
 }
+
+test "compile+run group join env survives let and orderby buffering" {
+    // Arrange — `join ... into g` yields the outer row env plus `g`; the `let`
+    // write and `orderby` buffering below hit that env across row-arena resets,
+    // so its bindings must be parent-owned, not row-arena aliased.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(state.io, .{ .sub_path = "a", .data = "a" });
+    try tmp.dir.writeFile(state.io, .{ .sub_path = "b", .data = "b" });
+    try tmp.dir.writeFile(state.io, .{ .sub_path = "cc", .data = "cc" });
+
+    const path = try tmpQueryPath(std.testing.allocator, tmp);
+    defer std.testing.allocator.free(path);
+
+    const a_path = try std.fs.path.join(std.testing.allocator, &.{ path, "a" });
+    defer std.testing.allocator.free(a_path);
+    const b_path = try std.fs.path.join(std.testing.allocator, &.{ path, "b" });
+    defer std.testing.allocator.free(b_path);
+    const cc_path = try std.fs.path.join(std.testing.allocator, &.{ path, "cc" });
+    defer std.testing.allocator.free(cc_path);
+
+    const query = try std.fmt.allocPrint(
+        std.testing.allocator,
+        \\from dir od in '{s}'
+        \\from file of in od
+        \\join file jf in od on of.size equals jf.size into g
+        \\let n = g.count()
+        \\orderby of.path
+        \\select {{ of.path, n }};
+    ,
+        .{path},
+    );
+    defer std.testing.allocator.free(query);
+
+    const expect = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "{s}\n2\n{s}\n2\n{s}\n1\n",
+        .{ a_path, b_path, cc_path },
+    );
+    defer std.testing.allocator.free(expect);
+
+    // Act
+    const got = try runQuery(query);
+
+    // Assert
+    try std.testing.expectEqualStrings("", got.err);
+    try std.testing.expectEqualStrings(expect, got.out);
+}

--- a/src/l2h/compile_test.zig
+++ b/src/l2h/compile_test.zig
@@ -41,6 +41,10 @@ fn runQuery(query: []const u8) !RunResult {
     state.had_error = false;
     state.syntax_check = false;
     diag.clearLast();
+    // Capture parse-time reports too (frontend_test asserts them via the same
+    // hook); runtime reports keep flowing through the AST callback as well.
+    diag.setOnReported(noteReported);
+    defer diag.setOnReported(null);
     run_err_len = 0;
     run_span = .{};
     out_writer = .fixed(&out_buf);
@@ -619,6 +623,42 @@ test "compile+run non-UTF-8 string payload hash reports payload error" {
 
     // Assert
     try std.testing.expectEqualStrings("string payload is not valid UTF-8 for this algorithm", got.err);
+}
+
+test "compile+run integer literal overflow reports range error" {
+    // Arrange — literals beyond i64 must be a compile error, not a silent 0
+    // that would quietly rewrite predicates like `f.size > <literal>`.
+    const cases = [_][]const u8{
+        "from string s in 'a' select 99999999999999999999999;",
+        "from string s in 'a' select -99999999999999999999999;",
+        "from file f in 'x' where f.size > 18446744073709551616 select f.path;",
+    };
+
+    for (cases) |q| {
+        // Act
+        const got = try runQuery(q);
+
+        // Assert
+        try std.testing.expectEqualStrings("integer literal out of range", got.err);
+    }
+}
+
+test "compile+run integer literal i64 boundaries parse exactly" {
+    // Arrange — both i64 extremes are representable and must not trip the
+    // overflow check (minInt arrives via the `-{DIGIT}+` lexer rule).
+    const cases = [_]struct { q: []const u8, want: []const u8 }{
+        .{ .q = "from string s in 'a' select 9223372036854775807;", .want = "9223372036854775807\n" },
+        .{ .q = "from string s in 'a' select -9223372036854775808;", .want = "-9223372036854775808\n" },
+    };
+
+    for (cases) |tc| {
+        // Act
+        const got = try runQuery(tc.q);
+
+        // Assert
+        try std.testing.expectEqualStrings("", got.err);
+        try std.testing.expectEqualStrings(tc.want, got.out);
+    }
 }
 
 test "compile+run non-UTF-8 payload hash-check reports payload error" {

--- a/src/l2h/diag.zig
+++ b/src/l2h/diag.zig
@@ -198,6 +198,7 @@ pub fn messageForRuntime(err: anyerror) []const u8 {
         error.Overflow => "value out of integer range",
         error.InvalidWindow => "limit/offset must be non-negative",
         error.BadRegex => "invalid regular expression",
+        error.InvalidStringPayload => "string payload is not valid UTF-8 for this algorithm",
         error.OffsetTooBig => blk: {
             if (pending_io_path_len == 0) break :blk modes.file.OFFSET_TOO_BIG;
             const path = pending_io_path[0..pending_io_path_len];

--- a/src/l2h/frontend.zig
+++ b/src/l2h/frontend.zig
@@ -264,9 +264,20 @@ pub export fn fend_query_strdup(str: [*c]u8) [*c]u8 {
     return dup.ptr;
 }
 
+/// Set by the most recent `fend_to_number` when the literal does not fit
+/// `c_longlong`; the lexer turns it into a parse error.
+pub export var fend_number_overflow: bool = false;
+
 pub export fn fend_to_number(str: [*c]u8) c_longlong {
     // Base-0 parse (decimal/hex/octal); 0 on failure.
-    return std.fmt.parseInt(c_longlong, span(str), 0) catch 0;
+    fend_number_overflow = false;
+    return std.fmt.parseInt(c_longlong, span(str), 0) catch |err| switch (err) {
+        error.Overflow => blk: {
+            fend_number_overflow = true;
+            break :blk 0;
+        },
+        else => 0,
+    };
 }
 
 // --- AST builders (grammar semantic actions) ------------------------------

--- a/src/l2h/grammar/frontend.h
+++ b/src/l2h/grammar/frontend.h
@@ -13,6 +13,8 @@
 #ifndef LINQ2HASH_FRONTEND_H_
 #define LINQ2HASH_FRONTEND_H_
 
+#include <stdbool.h>
+
 #include "types.h"
 
 #ifdef __cplusplus
@@ -124,6 +126,8 @@ char* fend_query_strdup(char* str);
 void fend_query_cleanup(fend_node_t* result);
 
 long long fend_to_number(char* str);
+/* Set by the last fend_to_number when the literal overflows long long. */
+extern bool fend_number_overflow;
 fend_node_t* fend_on_identifier_declaration(type_def_t type, fend_node_t* identifier);
 fend_node_t* fend_on_unary_expression(unary_exp_type_t type, void* leftValue, void* rightValue);
 fend_node_t* fend_on_number_literal(long long value);

--- a/src/l2h/grammar/l2h.lex
+++ b/src/l2h/grammar/l2h.lex
@@ -5,6 +5,8 @@
 	#include "frontend.h"
     #include "l2h.tab.h"
 
+	void lyyerror(YYLTYPE t, char *s, ...);
+
 	/* handle locations */
 	int yycolumn = 1;
 
@@ -139,8 +141,16 @@ ENDL [\r\n]
 {ENDL} { yycolumn = 1; }
 
 {IDENTIFIER} { yylval.string = fend_query_strdup(yytext); return IDENTIFIER; }
-{DIGIT}+ { yylval.number = fend_to_number(yytext); return INTEGER; }
--{DIGIT}+ { yylval.number = fend_to_number(yytext); return INTEGER; }
+{DIGIT}+ {
+    yylval.number = fend_to_number(yytext);
+    if (fend_number_overflow) lyyerror(yylloc, "integer literal out of range");
+    return INTEGER;
+}
+-{DIGIT}+ {
+    yylval.number = fend_to_number(yytext);
+    if (fend_number_overflow) lyyerror(yylloc, "integer literal out of range");
+    return INTEGER;
+}
 {BYTE_STRING} { yylval.string = fend_query_strdup(yytext); return BYTE_STRING; }
 {STRING} { yylval.string = fend_query_strdup(yytext); return STRING; }
 

--- a/src/l2h/interpret.zig
+++ b/src/l2h/interpret.zig
@@ -867,6 +867,10 @@ const JoinOp = struct {
     outer_key_val: Value = .{ .bool = false },
     /// Scratch / yield env: one clone of the outer, range binding overwritten per candidate.
     row: Env = .{},
+    /// Group-join yield env: parent-owned clone of the outer row plus the `into`
+    /// binding. The child row env's map lives in the row arena, which the next
+    /// pull recycles, so it must not be mutated or yielded with `pc.parent`.
+    group_env: Env = .{},
 
     fn open(self: *JoinOp, pc: *PipeCtx, outer: *Env) Error!void {
         self.clearInners(pc);
@@ -916,12 +920,12 @@ const JoinOp = struct {
                     }
                     const seq = try pc.parent.create(value.Seq);
                     seq.* = .{ .items = try pc.parent.dupe(Value, matches.items) };
-                    try self.outer_env.?.put(pc.parent, gname, .{ .seq = seq });
+                    self.group_env = try self.outer_env.?.clone(pc.parent);
+                    try self.group_env.put(pc.parent, gname, .{ .seq = seq });
                     if (!self.inners_cached) self.clearInners(pc);
                     pc.row_alloc = pc.parent;
-                    const out = self.outer_env.?;
                     self.outer_env = null;
-                    return out;
+                    return &self.group_env;
                 }
             }
             while (self.inner_index < self.inners.len) {

--- a/src/l2h/interpret.zig
+++ b/src/l2h/interpret.zig
@@ -41,6 +41,8 @@ pub const Error = error{
     BadRegex,
     /// File hash window starts past EOF (§4.5).
     OffsetTooBig,
+    /// UTF-16-widening algorithm (e.g. NTLM) got a non-UTF-8 `String` payload (§4.3).
+    InvalidStringPayload,
 } || std.mem.Allocator.Error;
 
 pub const Ctx = struct {
@@ -84,7 +86,12 @@ fn mapHashRestoreError(err: anyerror) Error {
 fn hashHexOfBytes(ctx: Ctx, algo: []const u8, bytes: []const u8) Error![]const u8 {
     const def = hashes.getHash(algo) orelse return error.UnknownHash;
     var digest: [modes.types.MAX_DIGEST_SIZE]u8 align(8) = std.mem.zeroes([modes.types.MAX_DIGEST_SIZE]u8);
-    modes.str.hashFromString(bytes, def, digest[0..def.hash_length], ctx.allocator) catch return error.IoFailure;
+    modes.str.hashFromString(bytes, def, digest[0..def.hash_length], ctx.allocator) catch |err| return switch (err) {
+        error.InvalidArgument => error.InvalidStringPayload,
+        error.OutOfMemory => error.OutOfMemory,
+        error.WriteFailed => error.WriteFailed,
+        error.UnknownHash => error.UnknownHash,
+    };
     var hex_buf: [modes.types.MAX_DIGEST_SIZE * 2]u8 = undefined;
     const hex = modes.types.hashToHex(digest[0..def.hash_length], true, &hex_buf);
     return try ctx.allocator.dupe(u8, hex);


### PR DESCRIPTION
- **fix(l2h): clone group-join yield env into the parent allocator**
- **fix(l2h): report non-UTF-8 string hashes as payload errors**
- **fix(gpu): zero GPU thread ctx slots before spawn**
- **fix(l2h): reject integer literals outside i64 range**
