### PR TITLE
fix(build): gate GPU backend and runtime libs on target OS

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -654,10 +654,12 @@ fn reportMissingNvcc(enable_opencl: bool) void {
 }
 
 /// CUDA/OpenCL artefacts match the host toolkit. Only native Windows and
-/// Linux gnu may link them; musl, macOS, and cross-arch use the CPU stub.
+/// Linux gnu may link them; musl, macOS, cross-arch, and cross-OS builds use
+/// the CPU stub (host nvcc emits host-format objects a cross-OS link rejects).
 fn targetSupportsGpuBackend(target: std.Build.ResolvedTarget) bool {
     const t = target.result;
     if (t.cpu.arch != builtin.cpu.arch) return false;
+    if (t.os.tag != builtin.os.tag) return false;
     return switch (t.os.tag) {
         .windows => true,
         .linux => t.abi.isGnu(),
@@ -799,7 +801,10 @@ fn attachCudaArchive(b: *std.Build, mod: *std.Build.Module) void {
     mod.linkSystemLibrary("cudart_static", .{ .preferred_link_mode = .static });
 
     // Linux nvcc host objects pull in these; Windows uses the MSVC/MinGW runtime.
-    if (builtin.os.tag == .linux) {
+    // Decide by the target OS, not the host: this archive must not leak host
+    // runtime libs into a cross-OS link.
+    const os = if (mod.resolved_target) |t| t.result.os.tag else builtin.os.tag;
+    if (os == .linux) {
         mod.linkSystemLibrary("dl", .{});
         mod.linkSystemLibrary("pthread", .{});
         mod.linkSystemLibrary("rt", .{});

--- a/src/hc/cli.zig
+++ b/src/hc/cli.zig
@@ -128,6 +128,30 @@ fn readNumberParam(
     }
 }
 
+/// Reads and validates a brute-force length bound (-n/-x): readNumberParam's
+/// contract plus the i32 range (`HashCtx.min`/`max` are i32). Returns the
+/// parsed value, or 0 when the option was not given (mode default marker).
+fn readLengthParam(
+    out: *std.Io.Writer,
+    provided: ?[]const u8,
+    option_name: []const u8,
+) !i32 {
+    const v = provided orelse return 0;
+    const n = parseBigNumber(v) catch {
+        try out.print("Invalid parameter --{s} {s}. Must be number\n", .{ option_name, v });
+        return error.InvalidArgument;
+    };
+    if (n < 0) {
+        try printCopyright(out);
+        try out.print("Invalid {s} option must be positive but was {d}\n", .{ option_name, n });
+        return error.InvalidArgument;
+    }
+    return std.math.cast(i32, n) orelse {
+        try out.print("Invalid parameter --{s} {s}. Must be a 32-bit number\n", .{ option_name, v });
+        return error.InvalidArgument;
+    };
+}
+
 // --- App construction (algorithm commands → mode subcommands) -------------
 
 /// Value-taking option that also accepts attached empty values (`-s=`).
@@ -404,8 +428,8 @@ fn runHash(
         .threads = threads,
     };
     if (matches.getSingleValue(opt_dict)) |d| hctx.dictionary = d;
-    if (matches.getSingleValue(opt_min)) |m| hctx.min = std.fmt.parseInt(i32, m, 10) catch 0;
-    if (matches.getSingleValue(opt_max)) |m| hctx.max = std.fmt.parseInt(i32, m, 10) catch 0;
+    hctx.min = try readLengthParam(env.out, matches.getSingleValue(opt_min), opt_min);
+    hctx.max = try readLengthParam(env.out, matches.getSingleValue(opt_max), opt_max);
 
     const h = try modes.builtinInit(bctx, env);
     try modes.hashRun(&hctx, env, h);
@@ -597,6 +621,44 @@ test "parseBigNumber clamps overflow to signed extremum" {
 test "parseBigNumber rejects non-numeric" {
     try std.testing.expectError(error.InvalidCharacter, parseBigNumber("a"));
     try std.testing.expectError(error.InvalidCharacter, parseBigNumber(""));
+}
+
+test "readLengthParam accepts absent and valid bounds" {
+    // Arrange
+    var buf: [512]u8 = undefined;
+    var writer: std.Io.Writer = .fixed(&buf);
+    const out = &writer;
+
+    // Act
+    const absent = try readLengthParam(out, null, opt_min);
+    const valid = try readLengthParam(out, "7", opt_max);
+
+    // Assert — absent keeps the 0 "use mode default" marker; nothing printed.
+    try std.testing.expectEqual(@as(i32, 0), absent);
+    try std.testing.expectEqual(@as(i32, 7), valid);
+    try std.testing.expectEqual(@as(usize, 0), std.Io.Writer.buffered(&writer).len);
+}
+
+test "readLengthParam rejects bad -n/-x values with a message" {
+    // Arrange — a silent catch-0 reset of the crack bounds is the bug this
+    // guards against (cf. --limit/--offset validation).
+    var buf: [512]u8 = undefined;
+    var writer: std.Io.Writer = .fixed(&buf);
+    const out = &writer;
+
+    // Act
+    const non_numeric = readLengthParam(out, "abc", opt_min);
+    const negative = readLengthParam(out, "-5", opt_max);
+    const too_big = readLengthParam(out, "3000000000", opt_max);
+
+    // Assert
+    try std.testing.expectError(error.InvalidArgument, non_numeric);
+    try std.testing.expectError(error.InvalidArgument, negative);
+    try std.testing.expectError(error.InvalidArgument, too_big);
+    const got = std.Io.Writer.buffered(&writer);
+    try std.testing.expect(std.mem.indexOf(u8, got, "Invalid parameter --min abc. Must be number") != null);
+    try std.testing.expect(std.mem.indexOf(u8, got, "Invalid max option must be positive but was -5") != null);
+    try std.testing.expect(std.mem.indexOf(u8, got, "Invalid parameter --max 3000000000. Must be a 32-bit number") != null);
 }
 
 test "algorithm names are pairwise distinct" {

--- a/src/hc/modes/dir.zig
+++ b/src/hc/modes/dir.zig
@@ -137,8 +137,10 @@ pub fn dirRun(
 
     // Search mode when an explicit --search hash OR a -m digest is present and
     // we are not in checksum-verify (-c) mode: only the matching file is
-    // emitted with its size.
-    const search_mode = (ctx.search_hash != null or ctx.opts.hash != null) and !ctx.opts.is_verify;
+    // emitted with its size. An empty target is ignored (calculateFile compares
+    // only non-empty hashes; an empty -m must not suppress all output).
+    const search_target = ctx.search_hash orelse ctx.opts.hash;
+    const search_mode = search_target != null and search_target.?.len > 0 and !ctx.opts.is_verify;
     const path = lib.trimQuotes(ctx.dir_path);
     const io = env.io;
     const allocator = env.allocator;
@@ -151,6 +153,18 @@ pub fn dirRun(
     defer tee.deinit();
     defer tee.finish(env);
     const sink_env = tee.sinkEnv(env);
+
+    // An invalid -m/--search hash fails for every file alike; validate once up
+    // front instead of hashing the tree just to emit nothing (file mode reports
+    // the same condition). Base64 stays off: file/dir -b is output-only.
+    if (search_mode) {
+        var probe: [t.MAX_DIGEST_SIZE]u8 align(8) = std.mem.zeroes([t.MAX_DIGEST_SIZE]u8);
+        t.parseSearchHash(search_target.?, false, hash_def, &probe) catch {
+            try sink_env.out.print("invalid search hash: {s}\n", .{search_target.?});
+            try tee.flush(env.out);
+            return;
+        };
+    }
 
     var root = std.Io.Dir.cwd().openDir(io, path, .{ .iterate = true }) catch {
         // `--noerroronfind` suppresses "cannot open directory".
@@ -361,6 +375,114 @@ test "dirRun search hash lists only matching files" {
     const got = std.Io.Writer.buffered(&writer);
     try std.testing.expect(std.mem.indexOf(u8, got, "match.txt") != null);
     try std.testing.expect(std.mem.indexOf(u8, got, "nomatch.txt") == null);
+}
+
+test "dirRun invalid -m search hash reports once and skips the walk" {
+    // Arrange — a bad -m digest is a query-level error: report it up front
+    // (file mode prints "invalid search hash" too) instead of hashing the
+    // tree only to suppress every line.
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const base = "modes_dir_bad_hash_probe";
+    const perms = std.Io.Dir.Permissions.default_dir;
+    std.Io.Dir.cwd().createDir(io, base, perms) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io, base) catch {};
+
+    var d = std.Io.Dir.cwd().openDir(io, base, .{ .iterate = true }) catch return;
+    var f1 = try d.createFile(io, "a.txt", .{});
+    try f1.writeStreamingAll(io, "aaa");
+    f1.close(io);
+    d.close(io);
+
+    var buf: [512]u8 = undefined;
+    var writer: std.Io.Writer = .fixed(&buf);
+    const env: t.RunEnv = .{
+        .io = io,
+        .allocator = std.testing.allocator,
+        .out = &writer,
+    };
+    const bctx: t.BuiltinCtx = .{ .hash_algorithm = "tiger" };
+    var dctx: t.DirCtx = .{
+        .opts = .{ .builtin = &bctx, .hash = "ZZZZ" },
+        .dir_path = base,
+        .recursively = true,
+    };
+
+    // Act
+    try dirRun(&dctx, env, hashes.getHash("tiger").?);
+
+    // Assert
+    const got = std.Io.Writer.buffered(&writer);
+    try std.testing.expect(std.mem.indexOf(u8, got, "invalid search hash: ZZZZ") != null);
+    try std.testing.expect(std.mem.indexOf(u8, got, "a.txt") == null);
+}
+
+test "dirRun invalid --search hash reports once and skips the walk" {
+    // Arrange — same validation for the explicit --search target.
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const base = "modes_dir_bad_search_probe";
+    const perms = std.Io.Dir.Permissions.default_dir;
+    std.Io.Dir.cwd().createDir(io, base, perms) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io, base) catch {};
+
+    var buf: [512]u8 = undefined;
+    var writer: std.Io.Writer = .fixed(&buf);
+    const env: t.RunEnv = .{
+        .io = io,
+        .allocator = std.testing.allocator,
+        .out = &writer,
+    };
+    const bctx: t.BuiltinCtx = .{ .hash_algorithm = "tiger" };
+    var dctx: t.DirCtx = .{
+        .opts = .{ .builtin = &bctx },
+        .dir_path = base,
+        .recursively = true,
+        .search_hash = "NOTHEX",
+    };
+
+    // Act
+    try dirRun(&dctx, env, hashes.getHash("tiger").?);
+
+    // Assert
+    const got = std.Io.Writer.buffered(&writer);
+    try std.testing.expect(std.mem.indexOf(u8, got, "invalid search hash: NOTHEX") != null);
+}
+
+test "dirRun empty search hash falls back to normal hashing" {
+    // Arrange — calculateFile compares only non-empty hashes; an empty
+    // --search must not switch into match-only mode and blank the output.
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const base = "modes_dir_empty_search_probe";
+    const perms = std.Io.Dir.Permissions.default_dir;
+    std.Io.Dir.cwd().createDir(io, base, perms) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io, base) catch {};
+
+    var d = std.Io.Dir.cwd().openDir(io, base, .{ .iterate = true }) catch return;
+    var f1 = try d.createFile(io, "a.txt", .{});
+    try f1.writeStreamingAll(io, "aaa");
+    f1.close(io);
+    d.close(io);
+
+    var buf: [512]u8 = undefined;
+    var writer: std.Io.Writer = .fixed(&buf);
+    const env: t.RunEnv = .{
+        .io = io,
+        .allocator = std.testing.allocator,
+        .out = &writer,
+    };
+    const bctx: t.BuiltinCtx = .{ .hash_algorithm = "tiger" };
+    var dctx: t.DirCtx = .{
+        .opts = .{ .builtin = &bctx },
+        .dir_path = base,
+        .recursively = true,
+        .search_hash = "",
+    };
+
+    // Act
+    try dirRun(&dctx, env, hashes.getHash("tiger").?);
+
+    // Assert
+    const got = std.Io.Writer.buffered(&writer);
+    try std.testing.expect(std.mem.indexOf(u8, got, "a.txt") != null);
 }
 
 test "dirRun continues after unreadable subdirectory" {

--- a/src/hc/modes/hash.zig
+++ b/src/hc/modes/hash.zig
@@ -15,6 +15,10 @@ pub fn hashRun(
     const dictionary = ctx.dictionary orelse bf.DEFAULT_ALPHABET;
     const passmin: i32 = if (ctx.min > 0) ctx.min else MIN_DEFAULT;
     const passmax: i32 = if (ctx.max > 0) ctx.max else @intCast(bf.MAX_DEFAULT);
+    if (passmin > passmax) {
+        try env.out.print("Minimum password length {d} is greater than maximum {d}\n", .{ passmin, passmax });
+        return error.InvalidArgument;
+    }
 
     var target: [t.MAX_DIGEST_SIZE]u8 align(8) = std.mem.zeroes([t.MAX_DIGEST_SIZE]u8);
     var has_target = false;
@@ -23,7 +27,11 @@ pub fn hashRun(
         try str.hashFromString(source, hash_def, target[0..hash_def.hash_length], env.allocator);
         has_target = true;
     } else if (ctx.hash != null and ctx.hash.?.len > 0) {
-        t.parseSearchHash(ctx.hash.?, ctx.is_base64, hash_def, &target) catch return error.InvalidArgument;
+        t.parseSearchHash(ctx.hash.?, ctx.is_base64, hash_def, &target) catch {
+            // main maps InvalidArgument to a silent exit 1: print the reason.
+            try env.out.print("invalid search hash: {s}\n", .{ctx.hash.?});
+            return error.InvalidArgument;
+        };
         has_target = true;
     }
     if (!has_target) return;
@@ -171,6 +179,65 @@ test "hashRun without hash writes nothing" {
     // Assert
     const out = std.Io.Writer.buffered(&writer);
     try std.testing.expectEqual(@as(usize, 0), out.len);
+}
+
+test "hashRun min greater than max reports and aborts" {
+    // Arrange — an inverted -n/-x range must abort up front instead of
+    // scanning a doomed odometer and reporting "Nothing found".
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    var buf: [256]u8 = undefined;
+    var writer: std.Io.Writer = .fixed(&buf);
+    const env: t.RunEnv = .{
+        .io = std.Io.Threaded.global_single_threaded.io(),
+        .allocator = arena.allocator(),
+        .out = &writer,
+    };
+
+    var ctx: t.HashCtx = .{
+        .builtin = &.{ .hash_algorithm = "tiger" },
+        .min = 5,
+        .max = 2,
+        .no_probe = true,
+        .threads = 1,
+    };
+
+    // Act
+    const err = hashRun(&ctx, env, hashes.getHash("tiger").?);
+
+    // Assert
+    try std.testing.expectError(error.InvalidArgument, err);
+    const out = std.Io.Writer.buffered(&writer);
+    try std.testing.expect(std.mem.indexOf(u8, out, "Minimum password length 5 is greater than maximum 2") != null);
+}
+
+test "hashRun invalid search hash reports and aborts" {
+    // Arrange — main maps InvalidArgument to a silent exit 1, so the mode
+    // must print the reason itself (parity with file/dir "invalid search hash").
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    var buf: [256]u8 = undefined;
+    var writer: std.Io.Writer = .fixed(&buf);
+    const env: t.RunEnv = .{
+        .io = std.Io.Threaded.global_single_threaded.io(),
+        .allocator = arena.allocator(),
+        .out = &writer,
+    };
+
+    var ctx: t.HashCtx = .{
+        .builtin = &.{ .hash_algorithm = "tiger" },
+        .hash = "ZZZZ",
+        .no_probe = true,
+        .threads = 1,
+    };
+
+    // Act
+    const err = hashRun(&ctx, env, hashes.getHash("tiger").?);
+
+    // Assert
+    try std.testing.expectError(error.InvalidArgument, err);
+    const out = std.Io.Writer.buffered(&writer);
+    try std.testing.expect(std.mem.indexOf(u8, out, "invalid search hash: ZZZZ") != null);
 }
 
 test "hashRun propagates writer failure not as OutOfMemory" {


### PR DESCRIPTION
Reject targets whose OS tag differs from the host in targetSupportsGpuBackend, so cross-OS builds fall back to the CPU stub (host nvcc emits host-format objects a cross-OS link rejects).

Decide whether attachCudaArchive links dl/pthread/rt by the resolved target OS instead of the host, preventing the CUDA archive from leaking host runtime libraries into cross-OS links.