### PR TITLE
fix(l2h): allow hyphenated hash names as properties (#333)

### DIFF
--- a/docs/l2h-semantics.md
+++ b/docs/l2h-semantics.md
@@ -202,6 +202,8 @@ In practice: put cheap predicates (`size`, `path`) before expensive ones (`<hash
 
 The syntax is `range.prop` for property access. **Method calls** use `receiver.method(args…)`, where the receiver can be either a range identifier or a record literal `{…}` (record literals only work for formatters; see §4.7). That covers Record formatters (§4.7), hash-check on `File`/`String` (§4.8), `Dir.tree()` / `Dir.skipErrors()` (§4.6), `File.offset(n)` / `File.limit(n)` (§4.5), `Hash.dict(s)` / `Hash.min(n)` / `Hash.max(n)` / `Hash.noProbe()` (§4.4), and `Seq.count()` (§4.9). Unknown methods, wrong arity, or an invalid receiver are all errors.
 
+Property and method names can include hyphens, so hash algorithms use the same spellings as `hc`: `s.sha-3-224`, `s.crc64-xz`, `s.haval-256-3`, and so on. Range names and record field names follow the same rule. A name can't end with `-`, and `--` isn't allowed. Negative integers like `-1` or `tree(-1)` are still ordinary number literals; there is no binary minus.
+
 ### 4.3 Property catalog
 
 Which properties are available depends entirely on the **runtime kind** of the receiver. Asking for a property a given kind doesn't have is an error, and ideally that gets caught statically, since the range type is usually already known at compile time.
@@ -689,6 +691,7 @@ This section exists to explain why the behavior is what it is. It's reference ma
 | `sfv` vs `checksum` | Lookup by field name; fixed emit order: `sfv` → `name    digest`, `checksum` → `digest path` |
 | File `name` | Basename of `path` (no I/O), required field name for `sfv()` |
 | Method receiver syntax | Identifier (`let` / `into`) or a record literal `{…}.method()` (§4.7) |
+| Hyphenated names | Ids, props, and methods may use hyphens so hash names match `hc` (`sha-3-224`); no trailing `-`; signed literals like `-1` stay separate (§4.2) |
 | Delimited methods | `csv` / `spaced` / `tabbed` still join in record field order |
 | `json` shape | One object per element (NDJSON when sunk per row); not a Seq-level JSON array |
 | Comments | `#…` lines of their own between queries are ignored; a comment can't sit inside a query body or after code on the same line (§5.1) |

--- a/src/l2h/compile_test.zig
+++ b/src/l2h/compile_test.zig
@@ -748,6 +748,73 @@ test "compile+run integer literal i64 boundaries parse exactly" {
     }
 }
 
+test "compile+run hyphenated hash property names" {
+    // Arrange — algorithm ids with '-' must be one IDENTIFIER (issue #333),
+    // not split into IDENT + negative INTEGER / INVALID.
+    const cases = [_]struct { q: []const u8, want: []const u8 }{
+        .{
+            .q = "from string s in 'abc' select s.sha-3-224;",
+            .want = "e642824c3f8cf24ad09234ee7d3c766fc9a3a5168d0c94ad73b46fdf\n",
+        },
+        .{
+            .q = "from string s in 'abc' select s.crc64-xz;",
+            .want = "2cd8094a1a277627\n",
+        },
+        .{
+            .q = "from string s in 'abc' select s.sha-3k-256;",
+            .want = "4e03657aea45a94fc7d47ba826c8d667c0d1e6e33a64a036ec44f58fa12d6c45\n",
+        },
+    };
+
+    for (cases) |tc| {
+        // Act
+        const got = try runQuery(tc.q);
+
+        // Assert
+        try std.testing.expectEqualStrings("", got.err);
+        try std.testing.expectEqualStrings(tc.want, got.out);
+    }
+}
+
+test "compile+run hyphenated hash-check method" {
+    // Arrange
+    const query =
+        "from string s in 'abc' select s.sha-3-224('e642824c3f8cf24ad09234ee7d3c766fc9a3a5168d0c94ad73b46fdf');";
+
+    // Act
+    const got = try runQuery(query);
+
+    // Assert
+    try std.testing.expectEqualStrings("", got.err);
+    try std.testing.expectEqualStrings("true\n", got.out);
+}
+
+test "compile+run unknown hyphenated property is not a syntax error" {
+    // Arrange — kebab name parses; catalog still rejects unknowns.
+    const query = "from string s in 'abc' select s.foo-bar;";
+
+    // Act
+    const got = try runQuery(query);
+
+    // Assert
+    try std.testing.expectEqualStrings("invalid property for this value type", got.err);
+}
+
+test "compile+run negative literal beside hyphenated property" {
+    // Arrange — signed INTEGER must stay separate from kebab IDENTIFIERs.
+    const query = "from string s in 'abc' where s.size > -1 select s.sha-3-224;";
+
+    // Act
+    const got = try runQuery(query);
+
+    // Assert
+    try std.testing.expectEqualStrings("", got.err);
+    try std.testing.expectEqualStrings(
+        "e642824c3f8cf24ad09234ee7d3c766fc9a3a5168d0c94ad73b46fdf\n",
+        got.out,
+    );
+}
+
 test "compile+run non-UTF-8 payload hash-check reports payload error" {
     // Arrange — same constraint via the hash-check method form (§4.8).
     const query = "from string s in b'\\xFF' where s.ntlm('00000000000000000000000000000000') select s;";

--- a/src/l2h/grammar/l2h.lex
+++ b/src/l2h/grammar/l2h.lex
@@ -76,9 +76,14 @@ LE "<="
 MATCH "~"
 NOTMATCH "!~"
 
+/* Identifiers are kebab-capable so hash props/methods match hc names
+ * (sha-3-224, crc64-xz, …). Segments: no leading digit, no trailing '-',
+ * no '--'. Longest-match still prefers a whole IDENTIFIER over adjacent
+ * -{DIGIT}+ integer tokens when glued (e.g. sha-3-224). Standalone
+ * negatives (select -1, tree(-1)) stay INTEGER via -{DIGIT}+. */
 ID_START  (_|[a-zA-Z])
 ID_PART   ({ID_START}|{DIGIT})
-IDENTIFIER ({ID_START}{ID_PART}*)
+IDENTIFIER ({ID_START}{ID_PART}*(-{ID_PART}+)*)
 
 COMMENT ^#[^\r\n]*
 


### PR DESCRIPTION
Lexer identifiers accept kebab segments so names like sha-3-224 match hc.