### PR TITLE
fix(bf): treat oversized passmax as hard error (#337)

### DIFF
--- a/src/hc/bf.zig
+++ b/src/hc/bf.zig
@@ -322,8 +322,9 @@ fn runBruteForce(
     gpu_context: ?*gpu.GpuContext,
 ) !?[]u8 {
     if (passmax > std.math.maxInt(c_int) / @sizeOf(c_int)) {
+        // Hard error: callers must not treat this as a miss (timings / Nothing found).
         try writer.print("Max string length is too big: {d}\n", .{passmax});
-        return null;
+        return error.InvalidArgument;
     }
 
     // Lengths 1..=3 crack instantly on CPU; GPU is overkill there.
@@ -633,7 +634,7 @@ test "crackHash aborts up front on oversized passmax" {
     var writer: std.Io.Writer = .fixed(&buf);
 
     // Act
-    const result = try crackHash(
+    const err = crackHash(
         arena_state.allocator(),
         io,
         &writer,
@@ -648,7 +649,9 @@ test "crackHash aborts up front on oversized passmax" {
     );
 
     // Assert
-    try std.testing.expect(result == null);
+    try std.testing.expectError(error.InvalidArgument, err);
     const got = std.Io.Writer.buffered(&writer);
     try std.testing.expect(std.mem.indexOf(u8, got, "Max string length is too big: 600000000") != null);
+    try std.testing.expect(std.mem.indexOf(u8, got, "Nothing found") == null);
+    try std.testing.expect(std.mem.indexOf(u8, got, "Attempts:") == null);
 }

--- a/src/hc/modes/hash.zig
+++ b/src/hc/modes/hash.zig
@@ -234,6 +234,43 @@ test "hashRun invalid search hash reports and aborts" {
     try std.testing.expect(std.mem.indexOf(u8, out, "invalid search hash: ZZZZ") != null);
 }
 
+test "hashRun oversized passmax reports and aborts" {
+    // Arrange
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    var buf: [256]u8 = undefined;
+    var writer: std.Io.Writer = .fixed(&buf);
+    const env: t.RunEnv = .{
+        .io = std.Io.Threaded.global_single_threaded.io(),
+        .allocator = arena.allocator(),
+        .out = &writer,
+    };
+
+    const tiger = hashes.getHash("tiger").?;
+    var digest: [24]u8 align(8) = undefined;
+    hashes.compute(tiger, "a", &digest);
+    var hexbuf: [48]u8 = undefined;
+    const hex = t.hashToHex(&digest, false, &hexbuf);
+
+    var ctx: t.HashCtx = .{
+        .hash = hex,
+        .dictionary = "a",
+        .min = 1,
+        .max = 600000000,
+        .no_probe = true,
+        .threads = 1,
+    };
+
+    // Act
+    const err = hashRun(&ctx, env, tiger);
+
+    // Assert
+    try std.testing.expectError(error.InvalidArgument, err);
+    const out = std.Io.Writer.buffered(&writer);
+    try std.testing.expect(std.mem.indexOf(u8, out, "Max string length is too big: 600000000") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "Nothing found") == null);
+}
+
 test "hashRun propagates writer failure not as OutOfMemory" {
     // Arrange
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);


### PR DESCRIPTION
Return InvalidArgument instead of null so crack does not print timings / Nothing found and exits non-zero.

fixes #337