### PR TITLE
fix(l2h): report oversized Hash.max as restore length, not invalid di…

### DIFF
--- a/docs/l2h-semantics.md
+++ b/docs/l2h-semantics.md
@@ -260,6 +260,8 @@ select x.dict('0123456789').min(1).max(3).noProbe().md5;
 
 `h.min(5).max(2)` is an error: min came out larger than max. `n = 0` is an error too. `hc hash` uses 0 to mean the option was omitted, not a length, so l2h will not store it.
 
+A max that fits `i32` can still be too large for restore (same cap as `hc hash -x`). That is a length error, not an invalid digest. The restore runner still prints `Max string length is too big: …`.
+
 The original binding is not mutated. Any restore property on that value (`x.md5`, `x.sha1`, …) uses its `dict`, `min`, `max`, and `noProbe` fields.
 
 Bare `h.dict` / `h.min` / `h.max` / `h.noProbe` read what's stored on the value. `where h.max == 10` compares integers; it does not change the bound. The methods are `Hash`-only; bare `h.min` on other kinds is still an invalid property (§4.3).
@@ -676,7 +678,7 @@ This section exists to explain why the behavior is what it is. It's reference ma
 | Multi-statement `into id;` | Bind in script env (no print); one row → scalar, many → `Seq`; later queries see the name (§5) |
 | `group proj by key` element | Record `{ key, items }` where `items` is the `Seq` of evaluated projections |
 | File `limit` / `offset` | `f.offset(n)` / `f.limit(n)` return a new `File`; properties only read; default `limit` is `maxInt(i64)`; hashes on that value follow `hc`; offset past EOF is an error (§4.5) |
-| Hash restore settings | `h.dict(s)` / `h.min(n)` / `h.max(n)` / `h.noProbe()` return a new `Hash`; bare properties only read; defaults match plain `hc hash`; `n ≥ 1` and fits `i32`; `min > max` is an error; restore uses the fields on the value (§4.4) |
+| Hash restore settings | `h.dict(s)` / `h.min(n)` / `h.max(n)` / `h.noProbe()` return a new `Hash`; bare properties only read; defaults match plain `hc hash`; `n ≥ 1` and fits `i32`; `min > max` is an error; oversized max at restore is a length error (same cap as `hc hash -x`); restore uses the fields on the value (§4.4) |
 | `~` / `!~` operands | Both **`String`** (subject ~ pattern); no stringify; empty matches count; bad pattern → runtime error; backtracking/depth cap → non-match (§5.3) |
 | `>` / `<` / `>=` / `<=` | **`Int`-only**; `String`/`Bool` ordering only via `orderby` (§5.3) |
 | Dir `tree` / `skipErrors` | `tree()` unlimited, `tree(n)` enter-depth limited (`tree(0)` ≡ flat); `skipErrors()` soft-skips walk/enter failures; compose freely; never follows symlinks; file order is walk order, sort with `orderby` (§4.6 / §3.4) |

--- a/src/hc/bf.zig
+++ b/src/hc/bf.zig
@@ -323,8 +323,9 @@ fn runBruteForce(
 ) !?[]u8 {
     if (passmax > std.math.maxInt(c_int) / @sizeOf(c_int)) {
         // Hard error: callers must not treat this as a miss (timings / Nothing found).
+        // Distinct from InvalidArgument (digest parse) so l2h can label length vs digest.
         try writer.print("Max string length is too big: {d}\n", .{passmax});
-        return error.InvalidArgument;
+        return error.PassmaxTooBig;
     }
 
     // Lengths 1..=3 crack instantly on CPU; GPU is overkill there.
@@ -658,7 +659,7 @@ test "crackHash aborts up front on oversized passmax" {
     );
 
     // Assert
-    try std.testing.expectError(error.InvalidArgument, err);
+    try std.testing.expectError(error.PassmaxTooBig, err);
     const got = std.Io.Writer.buffered(&writer);
     try std.testing.expect(std.mem.indexOf(u8, got, "Max string length is too big: 600000000") != null);
     try std.testing.expect(std.mem.indexOf(u8, got, "Nothing found") == null);

--- a/src/hc/main.zig
+++ b/src/hc/main.zig
@@ -99,6 +99,7 @@ pub fn main(init: std.process.Init) !void {
             // they have already printed a user-facing message.
             error.UnknownHash,
             error.InvalidArgument,
+            error.PassmaxTooBig,
             => std.process.exit(1),
             else => {
                 out.print("hc: {s}\n", .{@errorName(err)}) catch {};

--- a/src/hc/modes/hash.zig
+++ b/src/hc/modes/hash.zig
@@ -265,7 +265,7 @@ test "hashRun oversized passmax reports and aborts" {
     const err = hashRun(&ctx, env, tiger);
 
     // Assert
-    try std.testing.expectError(error.InvalidArgument, err);
+    try std.testing.expectError(error.PassmaxTooBig, err);
     const out = std.Io.Writer.buffered(&writer);
     try std.testing.expect(std.mem.indexOf(u8, out, "Max string length is too big: 600000000") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "Nothing found") == null);

--- a/src/l2h/compile_test.zig
+++ b/src/l2h/compile_test.zig
@@ -2116,6 +2116,19 @@ test "compile+run hash min greater than max is InvalidRestoreRange" {
     try std.testing.expect(std.mem.indexOf(u8, got.out, "Minimum password length") == null);
 }
 
+test "compile+run oversized hash.max is restore length not invalid digest" {
+    // Arrange
+    const query =
+        "from hash x in '202CB962AC59075B964B07152D234B70' select x.max(999999999).noProbe().md5;";
+
+    // Act
+    const got = try runQuery(query);
+
+    // Assert
+    try std.testing.expectEqualStrings("restore max length is too big", got.err);
+    try std.testing.expect(std.mem.indexOf(u8, got.out, "Max string length is too big: 999999999") != null);
+}
+
 test "compile+run invalid group property fails during compilation" {
     // Arrange
     const query =

--- a/src/l2h/diag.zig
+++ b/src/l2h/diag.zig
@@ -199,6 +199,7 @@ pub fn messageForRuntime(err: anyerror) []const u8 {
         error.InvalidWindow => "limit/offset must be non-negative",
         error.InvalidRestoreBound => "restore min/max must be at least 1",
         error.InvalidRestoreRange => "restore min length is greater than max",
+        error.InvalidRestoreLength => "restore max length is too big",
         error.BadRegex => "invalid regular expression",
         error.InvalidStringPayload => "string payload is not valid UTF-8 for this algorithm",
         error.OffsetTooBig => blk: {

--- a/src/l2h/interpret.zig
+++ b/src/l2h/interpret.zig
@@ -39,6 +39,8 @@ pub const Error = error{
     InvalidRestoreBound,
     /// `Hash.min` greater than `Hash.max` after a bound method (§4.4).
     InvalidRestoreRange,
+    /// Restore `Hash.max` exceeds the brute-force length cap (§4.4).
+    InvalidRestoreLength,
     /// Negative `tree(n)` depth (§4.6).
     InvalidTreeDepth,
     /// Invalid regex pattern for `~` / `!~` (§5.3 / §8).
@@ -78,6 +80,7 @@ fn ioFail(path: []const u8) Error {
 fn mapHashRestoreError(err: anyerror) Error {
     return switch (err) {
         error.InvalidArgument => error.InvalidHashDigest,
+        error.PassmaxTooBig => error.InvalidRestoreLength,
         error.UnknownHash => error.UnknownHash,
         error.OutOfMemory => error.OutOfMemory,
         error.WriteFailed => error.WriteFailed,
@@ -1617,7 +1620,7 @@ test "negative tree depth is InvalidTreeDepth" {
     try std.testing.expectError(error.InvalidTreeDepth, evalExpr(ctx, &call, &env, 0));
 }
 
-test "hash min/max reject zero negative overflow and inverted range" {
+test "hash min/max reject zero negative overflow inverted range and oversized max" {
     // Arrange
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -1662,6 +1665,15 @@ test "hash min/max reject zero negative overflow and inverted range" {
     var name_inv: Expr = .{ .kind = .{ .name = "inv" } };
     var md5_e: Expr = .{ .kind = .{ .prop = .{ .recv = &name_inv, .prop = "md5", .access = .hash_algo } } };
     try std.testing.expectError(error.InvalidRestoreRange, evalExpr(ctx, &md5_e, &env, 0));
+
+    try env.put(a, "huge", .{ .hash = .{
+        .digest = "202CB962AC59075B964B07152D234B70",
+        .max = 999999999,
+        .no_probe = true,
+    } });
+    var name_huge: Expr = .{ .kind = .{ .name = "huge" } };
+    var md5_huge: Expr = .{ .kind = .{ .prop = .{ .recv = &name_huge, .prop = "md5", .access = .hash_algo } } };
+    try std.testing.expectError(error.InvalidRestoreLength, evalExpr(ctx, &md5_huge, &env, 0));
 }
 
 test "sink record prints two lines" {


### PR DESCRIPTION
fixes #344